### PR TITLE
Add: script to send logs file to saas

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
   api_url:
     description: 'URL of the InvisiRisk API (required for prepare and setup modes)'
     required: false
+    default: 'https://app.invisirisk.com'
   app_token:
     description: 'Authentication token for the InvisiRisk API (required for prepare and setup modes)'
     required: false
@@ -56,6 +57,10 @@ inputs:
     description: 'Job status to be passed to the PSE container for job tracking'
     required: false
     default: 'unknown'
+  pse_tag:
+    description: 'Tag of the PSE container to be used for binary setup'
+    required: false
+    default: 'latest'
 # Define outputs for the action
 outputs:
   scan_id:
@@ -114,6 +119,7 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         CLEANUP_STEP_NAME: ${{ inputs.cleanup_step_name }}
+        PSE_TAG: ${{ inputs.pse_tag }}
     - if: ${{ inputs.cleanup == 'true' }}
       uses: actions/upload-artifact@v4
       with:

--- a/action.yml
+++ b/action.yml
@@ -91,8 +91,9 @@ runs:
           echo "Running PSE cleanup..."
           $GITHUB_ACTION_PATH/cleanup.sh
         elif [ "${{ inputs.send_job_status }}" = "true" ]; then
-          echo "Running PSE send job status..."
-        bash $GITHUB_ACTION_PATH/get_jobs_status.sh
+          echo "Running PSE send job status and post logs..."
+          bash $GITHUB_ACTION_PATH/get_jobs_status.sh
+          bash $GITHUB_ACTION_PATH/post_logs.sh
         else
           echo "Running PSE setup in ${{ inputs.mode }} mode..."
           $GITHUB_ACTION_PATH/setup.sh

--- a/get_jobs_status.sh
+++ b/get_jobs_status.sh
@@ -33,10 +33,6 @@ load_metadata_from_file() {
   fi
 }
 
-# Print current working directory
-echo "PWD"
-pwd
-
 # Call the function to load metadata from analytics_metadata.json
 load_metadata_from_file
 
@@ -162,8 +158,6 @@ fetch_github_jobs() {
   # Variable to store the response body and http status
   local response_body
   local http_status
-  debug "Sleeping for 5 seconds before fetching GitHub job statuses..."
-  sleep 5
   # Command to execute with retry logic
   local curl_cmd="http_status=\$(curl -sSL -w \"%{http_code}\" \
     -H \"Accept: application/vnd.github+json\" \

--- a/post_logs.sh
+++ b/post_logs.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+#
+# This script fetches the logs of the first completed job in a GitHub Actions workflow,
+# and uploads them to a specified SaaS platform.
+#
+# Dependencies: curl, jq, and optionally gh (GitHub CLI).
+
+set -euo pipefail
+
+# Set default for GitHub API version if not provided.
+readonly GITHUB_API_VERSION="${GITHUB_API_VERSION:-2022-11-28}"
+
+# Enable debug mode by setting DEBUG=true.
+readonly DEBUG="${DEBUG:-false}"
+
+# Array to keep track of temporary files and directories for cleanup.
+TEMP_ITEMS=()
+
+# --- Core Utility Functions ---
+
+#
+# Prints a debug message to stderr if DEBUG is true.
+#
+debug() {
+    if [[ "$DEBUG" == "true" ]]; then
+        # Use printf for safer, more consistent output.
+        printf "[DEBUG] %s\n" "$*" >&2
+    fi
+}
+
+#
+# Displays the content of a file for debugging purposes.
+#
+debug_cat_file() {
+    local file_to_cat="$1"
+    if [[ "$DEBUG" == "true" ]]; then
+        if [[ -s "$file_to_cat" ]]; then # -s checks if file exists and is not empty.
+            echo "--- Debug content of $file_to_cat start ---" >&2
+            cat "$file_to_cat" >&2
+            echo "--- Debug content of $file_to_cat end ---" >&2
+        else
+            debug "File '$file_to_cat' not found or is empty."
+        fi
+    fi
+}
+
+#
+# Schedules all items in the TEMP_ITEMS array for removal on script exit.
+#
+cleanup() {
+    if ((${#TEMP_ITEMS[@]} > 0)); then
+        debug "Cleaning up temporary items..."
+        for item in "${TEMP_ITEMS[@]}"; do
+            if [[ -e "$item" ]]; then # -e checks for file or directory existence.
+                rm -rf "$item"
+                debug "Removed: $item"
+            fi
+        done
+    fi
+}
+
+#
+# Set up a trap to call the cleanup function on script exit or interruption.
+#
+trap cleanup EXIT SIGHUP SIGINT SIGTERM
+
+#
+# Creates a temporary file or directory and schedules it for cleanup.
+# Usage: create_temp [-d] [suffix]
+#   -d: Create a directory instead of a file.
+#
+create_temp() {
+    local opts=()
+    local suffix=""
+    # Simple argument parsing.
+    if [[ "${1-}" == "-d" ]]; then
+        opts+=("-d")
+        shift
+    fi
+    suffix="${1:-}"
+
+    # Prefer /tmp, fallback to the current directory.
+    local temp_item
+    temp_item=$(mktemp "${opts[@]}" "/tmp/tmp.${suffix}.XXXXXX" 2>/dev/null) || temp_item=$(mktemp "${opts[@]}")
+
+    if [[ -z "$temp_item" ]] || [[ ! -e "$temp_item" ]]; then
+        printf "Error: Failed to create temporary item.\n" >&2
+        return 1
+    fi
+
+    TEMP_ITEMS+=("$temp_item")
+    debug "Created temp item: $temp_item"
+    echo "$temp_item"
+}
+
+# --- API and Command Execution Functions ---
+
+#
+# Checks if an HTTP status code is in the 2xx range.
+#
+check_http_status() {
+    local status_code="$1"
+    local error_message="$2"
+    local response_body_file="$3" # Pass file path instead of content for large responses.
+
+    if [[ "$status_code" =~ ^2[0-9]{2}$ ]]; then
+        return 0
+    else
+        printf "Error: %s\n" "$error_message" >&2
+        printf "Status code: %s\n" "$status_code" >&2
+        debug_cat_file "$response_body_file"
+        return 1
+    fi
+}
+
+#
+# Retries a command with exponential backoff.
+# SECURITY: This version avoids `eval` by executing the command directly.
+#
+retry_with_backoff() {
+    local max_attempts=3
+    local timeout=1
+    local attempt=1
+    local exit_code=0
+
+    # The command and its arguments are passed directly to this function.
+    debug "Executing with retry: $*"
+    while ((attempt <= max_attempts)); do
+        if ((attempt > 1)); then
+            printf "Retrying (%d/%d)...\n" "$attempt" "$max_attempts" >&2
+        fi
+
+        "$@"
+        exit_code=$?
+
+        if ((exit_code == 0)); then
+            return 0
+        fi
+
+        debug "Command failed with exit code $exit_code. Retrying in ${timeout}s..."
+        sleep "$timeout"
+        timeout=$((timeout * 2))
+        attempt=$((attempt + 1))
+    done
+
+    printf "Error: Command failed after %d attempts.\n" "$max_attempts" >&2
+    debug "Failed command: $*"
+    return "$exit_code"
+}
+
+# --- Application Logic ---
+
+#
+# Loads SCAN_ID from a metadata file. Supports jq with a grep/sed fallback.
+#
+load_metadata() {
+    local metadata_file="analytics_metadata.json"
+    if [[ ! -f "$metadata_file" ]]; then
+        debug "Metadata file not found: $metadata_file"
+        return
+    fi
+
+    debug "Loading SCAN_ID from $metadata_file"
+    if command -v jq &>/dev/null; then
+        SCAN_ID=$(jq -r '.scan_id // empty' "$metadata_file")
+    else
+        debug "jq not found. Falling back to grep/sed."
+        SCAN_ID=$(grep -o '"scan_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$metadata_file" | sed 's/.*"scan_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+    fi
+    debug "Loaded SCAN_ID=${SCAN_ID:-not_found}"
+}
+
+#
+# Validates that all required environment variables for the SaaS platform are set.
+#
+validate_saas_env_vars() {
+    local missing_vars=()
+    [[ -z "${API_URL:-}" ]] && missing_vars+=("API_URL")
+    [[ -z "${APP_TOKEN:-}" ]] && missing_vars+=("APP_TOKEN")
+    [[ -z "${SCAN_ID:-}" ]] && missing_vars+=("SCAN_ID")
+
+    if ((${#missing_vars[@]} > 0)); then
+        printf "Error: Missing required environment variables for SaaS integration: %s\n" "${missing_vars[*]}" >&2
+        return 1
+    fi
+}
+
+#
+# Fetches all jobs for the current GitHub workflow run.
+#
+fetch_github_workflow_jobs() {
+    local response_file
+    response_file=$(create_temp) || return 1
+
+    local http_status
+    local api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs"
+
+    debug "Fetching GitHub workflow jobs from: $api_url"
+    # We need to capture the http_status, so we run curl inside a subshell command.
+    # This is one of the few cases where building a command for a wrapper is complex.
+    # An alternative is to not wrap this specific curl call in retry_with_backoff.
+    # For simplicity, we'll keep the direct call here and add retry logic manually.
+    # Refactoring `retry_with_backoff` to handle this case would be overly complex.
+
+    http_status=$(curl -sSL --write-out "%{http_code}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
+        -o "$response_file" \
+        "$api_url")
+
+    if ! check_http_status "$http_status" "GitHub API call for jobs failed" "$response_file"; then
+        return 1
+    fi
+
+    cat "$response_file"
+}
+
+#
+# Downloads logs for a specific job ID via the GitHub API.
+# This is a helper function used as a fallback if `gh` CLI fails or is missing.
+#
+_download_logs_via_api() {
+    local job_id="$1"
+    local output_file="$2"
+    local redirect_url_file
+    local http_status
+    local api_url="${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs"
+
+    # 1. Get the redirect URL for the logs zip archive.
+    debug "Getting log redirect URL from API for job $job_id"
+    redirect_url_file=$(create_temp) || return 1
+    http_status=$(curl -sI -w "%{http_code}" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
+        -o "$redirect_url_file" \
+        "$api_url")
+
+    # The API for log download URL gives a 302 redirect. We need to check for that.
+    if [[ "$http_status" != "302" ]]; then
+        printf "Error: Failed to get log redirect URL for job %s (Status: %s)\n" "$job_id" "$http_status" >&2
+        return 1
+    fi
+
+    local redirect_url
+    redirect_url=$(grep -i '^location:' "$redirect_url_file" | awk '{print $2}' | tr -d '\r')
+
+    if [[ -z "$redirect_url" ]]; then
+        printf "Error: Could not parse redirect URL for job %s.\n" "$job_id" >&2
+        return 1
+    fi
+
+    # 2. Download the actual logs from the redirect URL.
+    debug "Downloading logs from redirect URL..."
+    http_status=$(curl -sL -w "%{http_code}" -o "$output_file" "$redirect_url")
+
+    if ! check_http_status "$http_status" "Failed to download logs from redirect URL" "$output_file"; then
+        return 1
+    fi
+
+    debug "Successfully downloaded logs via API for job $job_id"
+    return 0
+}
+
+#
+# Downloads logs for a given job ID. Prefers `gh` CLI and falls back to API.
+#
+download_job_logs() {
+    local job_id="$1"
+    local output_file="$2"
+
+    printf "Downloading logs for job: %s\n" "$job_id"
+
+    # Method 1: Use GitHub CLI (preferred)
+    if command -v gh &>/dev/null; then
+        debug "Attempting to download logs using 'gh' CLI..."
+        if retry_with_backoff gh run view --repo "$GITHUB_REPOSITORY" --job "$job_id" --log >"$output_file"; then
+            printf "✅ Saved logs for job %s using 'gh' CLI.\n" "$job_id"
+            return 0
+        else
+            printf "⚠️ 'gh' CLI command failed. Falling back to API method.\n" >&2
+        fi
+    else
+        debug "GitHub CLI 'gh' not found. Using API method directly."
+    fi
+
+    # Method 2: Fallback to direct API call
+    if _download_logs_via_api "$job_id" "$output_file"; then
+        printf "✅ Saved logs for job %s using API fallback.\n" "$job_id"
+        return 0
+    else
+        printf "❌ Failed to download logs for job %s after all attempts.\n" "$job_id" >&2
+        # Create an empty file to signify failure but prevent later steps from breaking
+        # on a non-existent file. Or return 1 to halt execution.
+        echo "Log download failed for job $job_id" >"$output_file"
+        return 1
+    fi
+}
+
+#
+# Sends a file to the SaaS platform.
+#
+send_file_to_saas() {
+    local file_path="$1"
+    local remote_filename="$2"
+
+    printf "Sending file '%s' to SaaS platform...\n" "$remote_filename"
+
+    if ! validate_saas_env_vars; then
+        printf "⚠️ Skipping SaaS upload due to missing environment variables.\n" >&2
+        return 1
+    fi
+
+    if [[ ! -s "$file_path" ]]; then
+        printf "Warning: File '%s' is empty or does not exist. Skipping upload.\n" "$file_path" >&2
+        return 1
+    fi
+
+    local response_file
+    response_file=$(create_temp "saas_api_response") || return 1
+
+    local api_url="${API_URL}/ingestionapi/v1/upload-generic-file"
+    local http_status
+
+    debug "Uploading to: $api_url"
+    debug "File size: $(wc -c <"$file_path") bytes"
+
+    # Using --fail-with-body for better error reporting in newer curl versions
+    http_status=$(curl -sSL -w "%{http_code}" \
+        -X POST \
+        -H "Accept: application/json" \
+        -H "Content-Type: multipart/form-data" \
+        -F "file=@${file_path};filename=${remote_filename}" \
+        -o "$response_file" \
+        "${api_url}?api_key=${APP_TOKEN}&scan_id=${SCAN_ID}&file_type=logs")
+
+    if ! check_http_status "$http_status" "SaaS API upload for '$remote_filename' failed" "$response_file"; then
+        return 1
+    fi
+
+    printf "✅ Successfully sent '%s' to SaaS platform.\n" "$remote_filename"
+    debug_cat_file "$response_file"
+}
+
+# --- Main Execution ---
+
+main() {
+    printf "Starting log fetching and analysis process...\n"
+
+    # Load SCAN_ID from file, if it exists. This can be overridden by env var.
+    load_metadata
+
+    # Fetch all jobs for the current workflow run
+    local all_jobs_data
+    all_jobs_data=$(fetch_github_workflow_jobs)
+
+    if [[ -z "$all_jobs_data" ]]; then
+        printf "⚠️ Failed to fetch job data from GitHub API or the response was empty.\n" >&2
+        return 0 # Not a fatal error, just nothing to process.
+    fi
+
+    # Check for jq dependency
+    if ! command -v jq &>/dev/null; then
+        printf "Error: 'jq' is not installed, which is required to parse job data.\n" >&2
+        return 1
+    fi
+
+    # Find the ID of the first job that has completed.
+    local first_completed_job_id
+    first_completed_job_id=$(echo "$all_jobs_data" | jq -r '([.jobs[]? | select(.status == "completed") | .id])[0]')
+
+    if [[ -z "$first_completed_job_id" ]]; then
+        printf "ℹ️ No completed jobs found in this workflow run.\n"
+        return 0
+    fi
+
+    debug "Found first completed job ID: $first_completed_job_id"
+
+    # Create a temporary file for the logs. It will be cleaned up automatically on exit.
+    local downloaded_log_file
+    downloaded_log_file=$(create_temp "joblog.txt") || return 1
+
+    if download_job_logs "$first_completed_job_id" "$downloaded_log_file"; then
+        local remote_filename="job_${first_completed_job_id}_logs.txt"
+        send_file_to_saas "$downloaded_log_file" "$remote_filename"
+    else
+        printf "❌ Process failed: Could not download logs for job %s.\n" "$first_completed_job_id"
+        return 1
+    fi
+
+    printf "Process completed successfully.\n"
+}
+
+# Execute the main function, passing all script arguments to it.
+main "$@"

--- a/scripts/mode_binary_setup.sh
+++ b/scripts/mode_binary_setup.sh
@@ -99,8 +99,8 @@ pull_and_start_pse_container() {
 
   # Define possible repository paths to try
   local REPO_PATHS=(
-    "$ECR_REGISTRY_ID.dkr.ecr.$ECR_REGION.amazonaws.com/invisirisk/pse-proxy:latest"
-    "invisirisk/pse-proxy:latest"
+    "$ECR_REGISTRY_ID.dkr.ecr.$ECR_REGION.amazonaws.com/invisirisk/pse-proxy:$PSE_TAG"
+    "invisirisk/pse-proxy:$PSE_TAG"
   )
 
   # Try to pull the PSE container from each repository path

--- a/scripts/mode_setup.sh
+++ b/scripts/mode_setup.sh
@@ -99,8 +99,8 @@ pull_and_start_pse_container() {
 
   # Define possible repository paths to try
   local REPO_PATHS=(
-    "$ECR_REGISTRY_ID.dkr.ecr.$ECR_REGION.amazonaws.com/invisirisk/pse-proxy:latest"
-    "invisirisk/pse-proxy:latest"
+    "$ECR_REGISTRY_ID.dkr.ecr.$ECR_REGION.amazonaws.com/invisirisk/pse-proxy:$PSE_TAG"
+    "invisirisk/pse-proxy:$PSE_TAG"
   )
 
   # Try to pull the PSE container from each repository path


### PR DESCRIPTION
feat: Post job logs to SaaS platform

## Summary

This PR enhances the action's post-execution step by adding the capability to automatically upload job logs to our SaaS platform. This provides valuable diagnostic data for analyzing workflow runs, making it easier to debug issues without manually downloading logs from the GitHub UI.

## Key Changes

### New `post_logs.sh` Script:
* A new, robust shell script (`post_logs.sh`) has been introduced to handle the logic for fetching and uploading logs.
* It automatically finds the first completed job in the current workflow run.
* It downloads the logs for that job, using the `gh` CLI for efficiency and falling back to the REST API for resilience.
* It uploads the log file to the `/ingestionapi/v1/upload-generic-file` endpoint, associating it with the current `SCAN_ID`.
* The script includes comprehensive error handling, retry logic, and automatic cleanup of temporary files.

### `action.yml` Integration:
* The `post` step in `action.yml` is updated to execute the new `post_logs.sh` script immediately after `get_jobs_status.sh` when the `send_job_status` input is `true`.

### `get_jobs_status.sh` Cleanup:
* Removed a hardcoded `sleep 5` and a `pwd` debugging command from the `get_jobs_status.sh` script to streamline its execution.

## How to Test

1. Run this action in a workflow with the `send_job_status` input set to `true`.
2. Ensure the workflow has at least one job that runs to completion.
3. After the workflow finishes, verify that the logs from the first completed job have been successfully uploaded to the SaaS platform and are visible under the corresponding `SCAN_ID`.