### PR TITLE
Refactor global variables and improve logging in cleanup.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,10 +56,6 @@ inputs:
     description: 'Job status to be passed to the PSE container for job tracking'
     required: false
     default: 'unknown'
-  upload_artifact:
-    description: 'Set to true to upload analytics metadata artifact'
-    required: false
-    default: 'true'
   collect_dependencies:
     description: 'Set to true to collect dependency graphs during cleanup, false to skip. Default is true if not specified.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: 'Set to true to collect dependency graphs during cleanup, false to skip. Default is true if not specified.'
     required: false
     default: ''
+  workdir:
+    description: 'Working directory to use as the project path for dependency graph collection. Defaults to the current directory (pwd) if not specified.'
+    required: false
+    default: ''
 # Define outputs for the action
 outputs:
   scan_id:
@@ -112,4 +116,5 @@ runs:
         GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         CLEANUP_STEP_NAME: ${{ inputs.cleanup_step_name }}
         COLLECT_DEPENDENCIES: ${{ inputs.collect_dependencies}}
+        WORKDIR: ${{ inputs.workdir }}
         

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -9,6 +9,9 @@ set -e
 # Get DEBUG flag (defaults to false)
 DEBUG="${DEBUG:-false}"
 
+# PSE Base URL
+PSE_BASE_URL="https://pse.invisirisk.com"
+
 
 # PSE debug logging (controlled by DEBUG flag)
 debug() {
@@ -171,7 +174,6 @@ collect_dependency_graphs() {
   debug "Starting dependency graph collection..."
 
   # Inline dependency graph collection
-  local PSE_BASE_URL="https://pse.invisirisk.com"
   local PROJECT_PATH="${GITHUB_WORKSPACE:-.}"
   local DEBUG_FLAG="${DEBUG:-false}"
   local INCLUDE_DEV_DEPS="${INCLUDE_DEV_DEPS:-true}"
@@ -209,8 +211,7 @@ signal_build_end() {
   fi
 
   # Default to PSE endpoint directly
-  BASE_URL="https://pse.invisirisk.com"
-  debug "Using default PSE endpoint: $BASE_URL"
+  debug "Using default PSE endpoint: $PSE_BASE_URL"
 
   # Build URL for the GitHub run
   build_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
@@ -230,7 +231,7 @@ signal_build_end() {
   while [ $ATTEMPT -le $MAX_RETRIES ]; do
     debug "Sending end signal, attempt $ATTEMPT of $MAX_RETRIES"
 
-    RESPONSE=$(curl -X POST "${BASE_URL}/end" \
+    RESPONSE=$(curl -X POST "${PSE_BASE_URL}/end" \
       -H 'Content-Type: application/x-www-form-urlencoded' \
       -H 'User-Agent: pse-action' \
       -d "$params" \
@@ -283,7 +284,7 @@ display_container_logs() {
   
   # Check if container exists
   if ! run_with_privilege docker ps -a --format "{{.Names}}" | grep -q "^${container_name}$"; then
-    log "No PSE proxy container found to display logs"
+    log "PSE proxy container '${container_name}' not found - skipping log display"
     return 0
   fi
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -174,7 +174,7 @@ collect_dependency_graphs() {
   debug "Starting dependency graph collection..."
 
   # Inline dependency graph collection
-  local PROJECT_PATH="${GITHUB_WORKSPACE:-.}"
+  local PROJECT_PATH="$(pwd)"
   local DEBUG_FLAG="${DEBUG:-false}"
   local INCLUDE_DEV_DEPS="${INCLUDE_DEV_DEPS:-true}"
   

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -174,7 +174,7 @@ collect_dependency_graphs() {
   debug "Starting dependency graph collection..."
 
   # Inline dependency graph collection
-  local PROJECT_PATH="$(pwd)"
+  local PROJECT_PATH="${IR_WORKDIR:-$(pwd)}"
   local DEBUG_FLAG="${DEBUG:-false}"
   local INCLUDE_DEV_DEPS="${INCLUDE_DEV_DEPS:-true}"
   

--- a/scripts/mode_prepare.sh
+++ b/scripts/mode_prepare.sh
@@ -134,7 +134,7 @@ get_ecr_credentials() {
   local HTTP_CODE
   RESPONSE=$(curl -L -s -w "\n%{http_code}" -X GET "$API_ENDPOINT")
   HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-  RESPONSE=$(echo "$RESPONSE" | sed '$d')
+  RESPONSE=$(echo "$RESPONSE" | sed '$d') # Remove trailing HTTP status code
 
   debug "API response status: $HTTP_CODE"
 

--- a/scripts/mode_prepare.sh
+++ b/scripts/mode_prepare.sh
@@ -260,6 +260,7 @@ set_outputs() {
   echo "DEBUG=${DEBUG:-false}" >>$GITHUB_ENV
   echo "INCLUDE_DEV_DEPS=${INCLUDE_DEV_DEPS:-true}" >>$GITHUB_ENV
   echo "PSE_COLLECT_DEPENDENCIES=${COLLECT_DEPENDENCIES:-true}" >>$GITHUB_ENV
+  echo "IR_WORKDIR=${WORKDIR:-}" >>$GITHUB_ENV
 
   # Debug: Confirm outputs were set
   if [ -f "$GITHUB_OUTPUT" ]; then


### PR DESCRIPTION
This pull request updates how the working directory is specified and used for dependency graph collection in the GitHub Action. The main changes remove the now-unnecessary `upload_artifact` input, add a new `workdir` input, and ensure this value is passed through the workflow and used by scripts for more flexible project path handling.

**Input and configuration changes:**

* Removed the `upload_artifact` input from `action.yml`, as it is no longer needed.
* Added a new `workdir` input to `action.yml` to allow specifying the working directory for dependency graph collection; defaults to the current directory if not set.
* Passed the new `workdir` input as the `WORKDIR` environment variable in the `runs` section of `action.yml`.

**Script and environment variable updates:**

* Updated `scripts/mode_prepare.sh` to set the `IR_WORKDIR` environment variable from the `WORKDIR` input, making it available for subsequent steps.
* Modified `cleanup.sh` so that `collect_dependency_graphs()` uses `IR_WORKDIR` as the project path, defaulting to the current directory if not set, improving flexibility for dependency collection.