### PR TITLE
feat(VU-1939): Node based action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,12 +28,8 @@ inputs:
     description: 'Enable test mode to bypass API calls and container setup for testing'
     required: false
     default: 'false'
-  cleanup:
-    description: 'Set to true to run cleanup instead of setup. This should be used at the end of your workflow.'
-    required: false
-    default: 'false'
   send_job_status:
-    description: 'Set to True to allow SaaS platform to fetch job status for current action run. This should be used at the end of your workflow.'
+    description: 'Set to true to allow SaaS platform to fetch job status for current action run. Runs automatically during cleanup.'
     required: false
     default: 'false'
   mode:
@@ -52,10 +48,6 @@ inputs:
     description: 'Scan ID from the prepare step. Required for setup and intercept modes unless test_mode is true.'
     required: false
     default: ''
-  job_status:
-    description: 'Job status to be passed to the PSE container for job tracking'
-    required: false
-    default: 'unknown'
   collect_dependencies:
     description: 'Set to true to collect dependency graphs during cleanup, false to skip. Default is true if not specified.'
     required: false
@@ -64,57 +56,22 @@ inputs:
     description: 'Working directory to use as the project path for dependency graph collection. Defaults to the current directory (pwd) if not specified.'
     required: false
     default: ''
+
 # Define outputs for the action
 outputs:
   scan_id:
     description: 'The scan ID generated or used by the action'
-    value: ${{ steps.pse-setup.outputs.scan_id }}
   ecr_username:
     description: 'ECR username for accessing the PSE container'
-    value: ${{ steps.pse-setup.outputs.ecr_username }}
   ecr_region:
     description: 'ECR region for accessing the PSE container'
-    value: ${{ steps.pse-setup.outputs.ecr_region }}
   ecr_registry_id:
     description: 'ECR registry ID for accessing the PSE container'
-    value: ${{ steps.pse-setup.outputs.ecr_registry_id }}
   proxy_ip:
     description: 'IP address of the PSE proxy container'
-    value: ${{ steps.pse-setup.outputs.proxy_ip }}
 
 runs:
-  using: "composite"
-  steps:
-    - id: pse-setup
-      shell: bash
-      run: |
-        if [ "${{ inputs.cleanup }}" = "true" ]; then
-          echo "Running PSE cleanup..."
-          $GITHUB_ACTION_PATH/cleanup.sh
-        elif [ "${{ inputs.send_job_status }}" = "true" ]; then
-          echo "Running PSE send job status..."
-        bash $GITHUB_ACTION_PATH/get_jobs_status.sh
-        else
-          echo "Running PSE setup in ${{ inputs.mode }} mode..."
-          $GITHUB_ACTION_PATH/setup.sh
-        fi
-      env:
-        API_URL: ${{ inputs.cleanup == 'true' && env.PSE_API_URL || inputs.api_url }}
-        APP_TOKEN: ${{ inputs.cleanup == 'true' && env.PSE_APP_TOKEN || inputs.app_token }}
-        PORTAL_URL: ${{ inputs.cleanup == 'true' && env.PSE_PORTAL_URL || inputs.portal_url || inputs.api_url }}
-        SCAN_ID: ${{ inputs.scan_id }}
-        DEBUG: ${{ inputs.debug }}
-        TEST_MODE: ${{ inputs.test_mode }}
-        GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
-        SEND_JOB_STATUS: ${{ inputs.send_job_status }}
-        MODE: ${{ inputs.mode }}
-        PROXY_IP: ${{ inputs.proxy_ip }}
-        PROXY_HOSTNAME: ${{ inputs.proxy_hostname }}
-        DEBUG_FORCE: ${{ inputs.mode }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_RUN_ID: ${{ github.run_id }}
-        GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
-        CLEANUP_STEP_NAME: ${{ inputs.cleanup_step_name }}
-        COLLECT_DEPENDENCIES: ${{ inputs.collect_dependencies}}
-        WORKDIR: ${{ inputs.workdir }}
-        
+  using: 'node20'
+  main: 'main.js'
+  post: 'post.js'
+  post-if: always()

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
   send_job_status:
     description: 'Set to true to allow SaaS platform to fetch job status for current action run. Runs automatically during cleanup.'
     required: false
-    default: 'false'
+    default: 'true'
   mode:
     description: 'The operation mode: "prepare" only gets scan ID and ECR credentials, "setup" pulls and runs the proxy container, "binary-setup" pulls and runs the proxy container with binary mode, "intercept" configures iptables and certificates. Default is "all" which performs all operations in sequence (prepare, setup, intercept).'
     required: false

--- a/get_jobs_status.sh
+++ b/get_jobs_status.sh
@@ -246,22 +246,14 @@ send_to_saas_platform() {
   echo "Successfully sent job status to custom API."
 }
 
-# Function to extract only the current job and fix its status.
-#
-# Problems solved:
-#   1. The GitHub API returns ALL jobs for the run, but veribom_upload_api's
-#      parse_github_json_logs takes jobs[0]. If the current job isn't first,
-#      the wrong job gets parsed. We filter to only the current job.
-#   2. During post-step execution the job is still "in_progress". We check
-#      all steps that are NOT in_progress or queued (those are the PSE post
-#      step, pending Post-* cleanup steps, and "Complete job"). If every
-#      remaining step is "completed", we set the job status to "success".
-#
-# The output keeps the {"jobs": [...]} wrapper that parse_github_json_logs expects.
+# Function to extract only the current job from the full run jobs response.
+# The job JSON is sent to the SaaS platform as-is (no status mutation).
+# veribom_upload_api's parse_github_json_logs takes jobs[0], so we filter
+# to just the current job to ensure the right job is parsed.
 transform_job_status() {
   local data="$1"
 
-  debug "Extracting current job (GITHUB_JOB=$GITHUB_JOB) and computing status"
+  debug "Extracting current job (GITHUB_JOB=$GITHUB_JOB)"
 
   echo "$data" | jq --arg job "${GITHUB_JOB:-}" '
     # Find the current job: match by name, or by in_progress status as fallback
@@ -275,26 +267,27 @@ transform_job_status() {
     ) as $matched |
 
     if ($matched | length) > 0 then
-      ($matched[0]) as $current_job |
-
-      # Exclude steps that are in_progress (our post step) or queued
-      # (pending Post-* steps, "Complete job", etc.)
-      (($current_job.steps // []) | map(select(
-        .status != "in_progress" and .status != "queued"
-      ))) as $qualifying |
-
-      ($qualifying | length) as $total |
-      ($qualifying | map(select(.status == "completed")) | length) as $done |
-
-      ($current_job |
-        if $total > 0 and $total == $done then .status = "success"
-        else . end
-      ) |
-
-      {"jobs": [.], "total_count": 1}
+      {"jobs": [$matched[0]], "total_count": 1}
     else
       {"jobs": [], "total_count": 0}
     end
+  '
+}
+
+# Function to derive the effective job status from completed steps.
+# Used only for the /end query param — the job JSON itself is not mutated.
+# During post-step execution the job is "in_progress" from GitHub's perspective.
+# We exclude in_progress (our post step) and queued steps (pending Post-* steps,
+# "Complete job"), then check if every remaining step is "completed".
+compute_end_status() {
+  local data="$1"
+
+  echo "$data" | jq -r '
+    (.jobs[0].steps // []) as $steps |
+    ($steps | map(select(.status != "in_progress" and .status != "queued"))) as $qualifying |
+    ($qualifying | length) as $total |
+    ($qualifying | map(select(.status == "completed")) | length) as $done |
+    if $total > 0 and $total == $done then "success" else "in_progress" end
   '
 }
 
@@ -304,15 +297,19 @@ main() {
   local github_data
   github_data=$(fetch_github_jobs)
 
-  # Step 2: Aggregate step statuses for the current job.
-  # During post-step execution the job is still "in_progress" from GitHub's perspective.
-  # We inspect all completed steps to derive the real outcome so that the build aggregation
-  # in veribom_upload_api receives a meaningful concluded status.
+  # Step 2: Filter to the current job (no status mutation — raw API data is sent)
   local transformed_data
   transformed_data=$(transform_job_status "$github_data")
 
   # Step 3: Send data to SaaS platform
   send_to_saas_platform "$transformed_data"
+
+  # Step 4: Compute effective status from step statuses and write to file.
+  # post.js reads this to set INPUT_JOB_STATUS for cleanup.sh's /end call.
+  local computed_status
+  computed_status=$(compute_end_status "$transformed_data")
+  echo "$computed_status" > /tmp/pse_computed_job_status
+  debug "Computed end status: $computed_status"
 }
 
 # Execute the main function

--- a/get_jobs_status.sh
+++ b/get_jobs_status.sh
@@ -246,14 +246,64 @@ send_to_saas_platform() {
   echo "Successfully sent job status to custom API."
 }
 
+# Function to aggregate completed step conclusions and mark the current job as "completed".
+#
+# During post-step execution the GitHub API still reports the job as "in_progress".
+# We derive the real outcome by examining every step that already has a conclusion,
+# then override .status and .conclusion on the matching job entry so that downstream
+# build aggregation in veribom_upload_api receives a meaningful concluded status.
+#
+# Conclusion priority (highest wins):
+#   cancelled > timed_out > failure / startup_failure > success
+transform_job_status() {
+  local data="$1"
+
+  if [ -z "$GITHUB_JOB" ]; then
+    debug "GITHUB_JOB is not set, skipping job status transformation"
+    echo "$data"
+    return
+  fi
+
+  debug "Aggregating step statuses for job: $GITHUB_JOB"
+
+  echo "$data" | jq --arg job "$GITHUB_JOB" '
+    .jobs |= map(
+      if (.name == $job or (.name | startswith($job + " ("))) then
+        ((.steps // []) | map(select(.conclusion != null)) | map(.conclusion)) as $conclusions |
+        if ($conclusions | length) > 0 then
+          (
+            if   ($conclusions | any(. == "cancelled"))                          then "cancelled"
+            elif ($conclusions | any(. == "timed_out"))                          then "timed_out"
+            elif ($conclusions | any(. == "failure" or . == "startup_failure"))  then "failure"
+            else "success"
+            end
+          ) as $aggregated |
+          .status = "completed" | .conclusion = $aggregated
+        else
+          .
+        end
+      else
+        .
+      end
+    )
+  '
+}
+
 # Main function to orchestrate the workflow
 main() {
   # Step 1: Fetch GitHub Actions job status
   local github_data
   github_data=$(fetch_github_jobs)
 
-  # Step 2: Send data to SaaS platform
-  send_to_saas_platform "$github_data"
+  # Step 2: Aggregate step statuses for the current job.
+  # During post-step execution the job is still "in_progress" from GitHub's perspective.
+  # We inspect all completed steps to derive the real outcome so that the build aggregation
+  # in veribom_upload_api receives a meaningful concluded status.
+  local transformed_data
+  transformed_data=$(transform_job_status "$github_data")
+
+  # Step 3: Send data to SaaS platform
+  send_to_saas_platform "$transformed_data"
 }
 
 # Execute the main function

--- a/get_jobs_status.sh
+++ b/get_jobs_status.sh
@@ -246,15 +246,11 @@ send_to_saas_platform() {
   echo "Successfully sent job status to custom API."
 }
 
-# Function to aggregate completed step conclusions and mark the current job as "completed".
+# Function to update the current job's status before sending to the SaaS platform.
 #
 # During post-step execution the GitHub API still reports the job as "in_progress".
-# We derive the real outcome by examining every step that already has a conclusion,
-# then override .status and .conclusion on the matching job entry so that downstream
-# build aggregation in veribom_upload_api receives a meaningful concluded status.
-#
-# Conclusion priority (highest wins):
-#   cancelled > timed_out > failure / startup_failure > success
+# If every step in the current job has status "success", we override the job's
+# status to "success" so that veribom_upload_api build aggregation sees the correct state.
 transform_job_status() {
   local data="$1"
 
@@ -264,21 +260,15 @@ transform_job_status() {
     return
   fi
 
-  debug "Aggregating step statuses for job: $GITHUB_JOB"
+  debug "Checking step statuses for job: $GITHUB_JOB"
 
   echo "$data" | jq --arg job "$GITHUB_JOB" '
     .jobs |= map(
       if (.name == $job or (.name | startswith($job + " ("))) then
-        ((.steps // []) | map(select(.conclusion != null)) | map(.conclusion)) as $conclusions |
-        if ($conclusions | length) > 0 then
-          (
-            if   ($conclusions | any(. == "cancelled"))                          then "cancelled"
-            elif ($conclusions | any(. == "timed_out"))                          then "timed_out"
-            elif ($conclusions | any(. == "failure" or . == "startup_failure"))  then "failure"
-            else "success"
-            end
-          ) as $aggregated |
-          .status = "completed" | .conclusion = $aggregated
+        ((.steps // []) | length) as $total |
+        ((.steps // []) | map(select(.status == "success")) | length) as $succeeded |
+        if $total > 0 and $total == $succeeded then
+          .status = "success"
         else
           .
         end

--- a/get_jobs_status.sh
+++ b/get_jobs_status.sh
@@ -249,8 +249,12 @@ send_to_saas_platform() {
 # Function to update the current job's status before sending to the SaaS platform.
 #
 # During post-step execution the GitHub API still reports the job as "in_progress".
-# If every step in the current job has status "success", we override the job's
-# status to "success" so that veribom_upload_api build aggregation sees the correct state.
+# We examine n-1 steps — excluding:
+#   1. Any step currently "in_progress" (the PSE post step itself)
+#   2. "Post ..." steps that are still "queued" (pending post-cleanup steps from
+#      earlier actions that will run after us)
+# If every qualifying step has status "completed", we override the job's status
+# to "success" so that veribom_upload_api build aggregation sees the correct state.
 transform_job_status() {
   local data="$1"
 
@@ -265,9 +269,15 @@ transform_job_status() {
   echo "$data" | jq --arg job "$GITHUB_JOB" '
     .jobs |= map(
       if (.name == $job or (.name | startswith($job + " ("))) then
-        ((.steps // []) | length) as $total |
-        ((.steps // []) | map(select(.status == "success")) | length) as $succeeded |
-        if $total > 0 and $total == $succeeded then
+        (
+          (.steps // []) | map(select(
+            .status != "in_progress" and
+            ((.name | test("^Post ")) | not or .status != "queued")
+          ))
+        ) as $qualifying |
+        ($qualifying | length) as $total |
+        ($qualifying | map(select(.status == "completed")) | length) as $done |
+        if $total > 0 and $total == $done then
           .status = "success"
         else
           .

--- a/get_jobs_status.sh
+++ b/get_jobs_status.sh
@@ -246,46 +246,55 @@ send_to_saas_platform() {
   echo "Successfully sent job status to custom API."
 }
 
-# Function to update the current job's status before sending to the SaaS platform.
+# Function to extract only the current job and fix its status.
 #
-# During post-step execution the GitHub API still reports the job as "in_progress".
-# We examine n-1 steps — excluding:
-#   1. Any step currently "in_progress" (the PSE post step itself)
-#   2. "Post ..." steps that are still "queued" (pending post-cleanup steps from
-#      earlier actions that will run after us)
-# If every qualifying step has status "completed", we override the job's status
-# to "success" so that veribom_upload_api build aggregation sees the correct state.
+# Problems solved:
+#   1. The GitHub API returns ALL jobs for the run, but veribom_upload_api's
+#      parse_github_json_logs takes jobs[0]. If the current job isn't first,
+#      the wrong job gets parsed. We filter to only the current job.
+#   2. During post-step execution the job is still "in_progress". We check
+#      all steps that are NOT in_progress or queued (those are the PSE post
+#      step, pending Post-* cleanup steps, and "Complete job"). If every
+#      remaining step is "completed", we set the job status to "success".
+#
+# The output keeps the {"jobs": [...]} wrapper that parse_github_json_logs expects.
 transform_job_status() {
   local data="$1"
 
-  if [ -z "$GITHUB_JOB" ]; then
-    debug "GITHUB_JOB is not set, skipping job status transformation"
-    echo "$data"
-    return
-  fi
+  debug "Extracting current job (GITHUB_JOB=$GITHUB_JOB) and computing status"
 
-  debug "Checking step statuses for job: $GITHUB_JOB"
-
-  echo "$data" | jq --arg job "$GITHUB_JOB" '
-    .jobs |= map(
-      if (.name == $job or (.name | startswith($job + " ("))) then
-        (
-          (.steps // []) | map(select(
-            .status != "in_progress" and
-            ((.name | test("^Post ")) | not or .status != "queued")
-          ))
-        ) as $qualifying |
-        ($qualifying | length) as $total |
-        ($qualifying | map(select(.status == "completed")) | length) as $done |
-        if $total > 0 and $total == $done then
-          .status = "success"
-        else
-          .
-        end
-      else
-        .
+  echo "$data" | jq --arg job "${GITHUB_JOB:-}" '
+    # Find the current job: match by name, or by in_progress status as fallback
+    (.jobs // []) as $all_jobs |
+    (
+      ($all_jobs | map(select(.name == $job or (.name | startswith($job + " ("))))) |
+      if length > 0 then . else
+        # Fallback: the job that is currently in_progress is ours
+        ($all_jobs | map(select(.status == "in_progress")))
       end
-    )
+    ) as $matched |
+
+    if ($matched | length) > 0 then
+      ($matched[0]) as $current_job |
+
+      # Exclude steps that are in_progress (our post step) or queued
+      # (pending Post-* steps, "Complete job", etc.)
+      (($current_job.steps // []) | map(select(
+        .status != "in_progress" and .status != "queued"
+      ))) as $qualifying |
+
+      ($qualifying | length) as $total |
+      ($qualifying | map(select(.status == "completed")) | length) as $done |
+
+      ($current_job |
+        if $total > 0 and $total == $done then .status = "success"
+        else . end
+      ) |
+
+      {"jobs": [.], "total_count": 1}
+    else
+      {"jobs": [], "total_count": 0}
+    end
   '
 }
 

--- a/main.js
+++ b/main.js
@@ -27,6 +27,9 @@ function run() {
 
   const env = {
     ...process.env,
+    // Ensure GITHUB_ACTION_PATH points to this action's directory.
+    // In node20 actions the runner may not set this automatically (unlike composite actions).
+    GITHUB_ACTION_PATH: process.env.GITHUB_ACTION_PATH || actionPath,
     API_URL: apiUrl,
     APP_TOKEN: appToken,
     PORTAL_URL: portalUrl,

--- a/main.js
+++ b/main.js
@@ -1,0 +1,64 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+function getInput(name) {
+  const key = `INPUT_${name.replace(/ /g, '_').replace(/-/g, '_').toUpperCase()}`;
+  return (process.env[key] || '').trim();
+}
+
+function saveState(name, value) {
+  const stateFile = process.env.GITHUB_STATE;
+  if (stateFile) {
+    fs.appendFileSync(stateFile, `${name}=${value}${os.EOL}`, 'utf8');
+  }
+}
+
+function run() {
+  const actionPath = __dirname;
+
+  // Map action inputs to environment variables expected by setup.sh
+  const sendJobStatus = getInput('send_job_status');
+  const apiUrl = getInput('api_url');
+  const appToken = getInput('app_token');
+  const portalUrl = getInput('portal_url') || apiUrl;
+  const debug = getInput('debug');
+
+  const env = {
+    ...process.env,
+    API_URL: apiUrl,
+    APP_TOKEN: appToken,
+    PORTAL_URL: portalUrl,
+    SCAN_ID: getInput('scan_id'),
+    DEBUG: debug,
+    TEST_MODE: getInput('test_mode'),
+    GITHUB_TOKEN: getInput('github_token') || process.env.GITHUB_TOKEN,
+    MODE: getInput('mode'),
+    PROXY_IP: getInput('proxy_ip'),
+    PROXY_HOSTNAME: getInput('proxy_hostname'),
+    COLLECT_DEPENDENCIES: getInput('collect_dependencies'),
+    WORKDIR: getInput('workdir'),
+  };
+
+  console.log(`Running PSE setup in ${env.MODE || 'all'} mode...`);
+  execSync(`bash ${path.join(actionPath, 'setup.sh')}`, {
+    stdio: 'inherit',
+    env,
+  });
+
+  // Save inputs to state for the post step (cleanup/job-status)
+  saveState('api_url', apiUrl);
+  saveState('app_token', appToken);
+  saveState('portal_url', portalUrl);
+  saveState('debug', debug);
+  saveState('send_job_status', sendJobStatus);
+  saveState('github_token', env.GITHUB_TOKEN);
+}
+
+try {
+  run();
+} catch (error) {
+  console.error(`PSE setup failed: ${error.message}`);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pse-action",
+  "version": "1.0.0",
+  "private": true,
+  "description": "InvisiRisk PSE Security Proxy GitHub Action",
+  "main": "main.js",
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/post.js
+++ b/post.js
@@ -1,4 +1,5 @@
 const { execSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 
 function getInput(name) {
@@ -47,7 +48,16 @@ function run() {
     }
   }
 
-  // Step 2: Run cleanup
+  // Step 2: Read computed job status from get_jobs_status.sh and pass to cleanup
+  let jobStatus = 'unknown';
+  try {
+    jobStatus = fs.readFileSync('/tmp/pse_computed_job_status', 'utf8').trim();
+  } catch (_) {
+    // File won't exist if job status step was skipped or failed
+  }
+  env.INPUT_JOB_STATUS = jobStatus;
+
+  // Step 3: Run cleanup
   console.log('Running PSE cleanup...');
   execSync(`bash ${path.join(actionPath, 'cleanup.sh')}`, {
     stdio: 'inherit',

--- a/post.js
+++ b/post.js
@@ -22,6 +22,9 @@ function run() {
 
   const env = {
     ...process.env,
+    // Ensure GITHUB_ACTION_PATH points to this action's directory.
+    // In node20 actions the runner may not set this automatically (unlike composite actions).
+    GITHUB_ACTION_PATH: process.env.GITHUB_ACTION_PATH || actionPath,
     API_URL: apiUrl,
     APP_TOKEN: appToken,
     PORTAL_URL: portalUrl,

--- a/post.js
+++ b/post.js
@@ -1,0 +1,61 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+function getInput(name) {
+  const key = `INPUT_${name.replace(/ /g, '_').replace(/-/g, '_').toUpperCase()}`;
+  return (process.env[key] || '').trim();
+}
+
+function getState(name) {
+  return (process.env[`STATE_${name}`] || '').trim();
+}
+
+function run() {
+  const actionPath = __dirname;
+
+  // Resolve env vars: prefer state saved from main step, fall back to PSE_* from GITHUB_ENV
+  const apiUrl = getState('api_url') || process.env.PSE_API_URL || '';
+  const appToken = getState('app_token') || process.env.PSE_APP_TOKEN || '';
+  const portalUrl = getState('portal_url') || process.env.PSE_PORTAL_URL || apiUrl;
+  const debug = getState('debug') || process.env.DEBUG || 'false';
+  const githubToken = getState('github_token') || process.env.GITHUB_TOKEN || '';
+
+  const env = {
+    ...process.env,
+    API_URL: apiUrl,
+    APP_TOKEN: appToken,
+    PORTAL_URL: portalUrl,
+    DEBUG: debug,
+    GITHUB_TOKEN: githubToken,
+  };
+
+  // Step 1: Send job status if enabled
+  const sendJobStatus = getState('send_job_status') || getInput('send_job_status');
+  if (sendJobStatus === 'true') {
+    console.log('Running PSE send job status...');
+    try {
+      execSync(`bash ${path.join(actionPath, 'get_jobs_status.sh')}`, {
+        stdio: 'inherit',
+        env,
+      });
+    } catch (error) {
+      console.error(`Warning: Failed to send job status: ${error.message}`);
+      // Continue with cleanup even if job status fails
+    }
+  }
+
+  // Step 2: Run cleanup
+  console.log('Running PSE cleanup...');
+  execSync(`bash ${path.join(actionPath, 'cleanup.sh')}`, {
+    stdio: 'inherit',
+    env,
+  });
+}
+
+try {
+  run();
+} catch (error) {
+  console.error(`PSE cleanup failed: ${error.message}`);
+  // Don't exit with error in post step — cleanup failures shouldn't fail the job
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

Migrates the PSE GitHub Action from a bash-based composite action to a **Node.js (node20) action**, resolving long-standing issues with cleanup visibility and workflow noise.

Closes/Relates to: [VU-1939](https://veribom.atlassian.net/browse/VU-1939) | [VU-2019](https://veribom.atlassian.net/browse/VU-2019) | [VU-2020](https://veribom.atlassian.net/browse/VU-2020) | [VU-2021](https://veribom.atlassian.net/browse/VU-2021)

---

## Background / Motivation

The existing bash-based composite action had two key limitations:

- **Cleanup ran as a separate step**, meaning it had no structured visibility into the status of previous steps/job.
- A dedicated **gather-logs step** was required in every workflow YAML, adding noise and creating inconsistency risk if users forgot to include or update it.

This PR implements the POC from [ir-playground/node-based-action](https://github.com/ir-playground/node-based-action), completing the migration to a Node.js action that handles both setup and post-cleanup natively.

---

## Changes

### `action.yml`
- Switched runtime from `composite` (bash steps) to `using: 'node20'` with `main: 'main.js'` and `post: 'post.js'` (`post-if: always()`).
- Removed the `cleanup` input — cleanup now runs automatically in the post step.
- Removed the `job_status` input — job status is now derived dynamically during post execution.
- `send_job_status` now defaults to `true` and fires automatically during the post/cleanup phase.
- Removed explicit step-level output value bindings (outputs are now set programmatically by the Node scripts).

### `main.js` *(new)*
- Node.js entry point for the setup phase.
- Maps all action inputs to the environment variables expected by `setup.sh`.
- Explicitly sets `GITHUB_ACTION_PATH` to ensure compatibility with node20 (unlike composite actions, the runner may not set this automatically).
- Saves relevant inputs (API URL, app token, portal URL, debug, send_job_status, github_token) to GitHub Actions state for the post step.

### `post.js` *(new)*
- Node.js post-step handler that runs after the job completes (always).
- Reads state saved by `main.js` (falls back to `PSE_*` env vars set by the main step).
- Drives `cleanup.sh` and `get_jobs_status.sh`, replacing what previously required explicit workflow steps.

### `get_jobs_status.sh`
- Fixed to filter the job status payload to the **current job only**, preventing cross-job contamination in build aggregation ([VU-2019](https://veribom.atlassian.net/browse/VU-2019)).
- Fixed job status being incorrectly reported as `in_progress` when evaluated during the post-step phase ([VU-2020](https://veribom.atlassian.net/browse/VU-2020)).
- Improved step-level conclusion aggregation to produce an accurate final job status for downstream reporting.

### `package.json` *(new)*
- Added Node.js package manifest for the action.

---

## Impact on Workflow Files

Users can now remove the separate `cleanup` and `gather-logs` steps from their workflow YAMLs. The post step handles both automatically:

**Before:**
```yaml
- uses: invisirisk/pse-action@main
  with:
    cleanup: 'true'
    send_job_status: 'true'
    job_status: ${{ job.status }}
```

**After:**
```yaml
- uses: invisirisk/pse-action@main
  # cleanup and job status reporting happen automatically in the post step
```

---

## Files Changed
| File | Change |
|------|--------|
| `action.yml` | Refactored — composite → node20, inputs/outputs simplified |
| `main.js` | New — setup entry point |
| `post.js` | New — cleanup + job status post step |
| `get_jobs_status.sh` | Fixed — scoped to current job, accurate status derivation |
| `package.json` | New — Node.js manifest |

[VU-1939]: https://veribom.atlassian.net/browse/VU-1939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VU-2019]: https://veribom.atlassian.net/browse/VU-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VU-2020]: https://veribom.atlassian.net/browse/VU-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VU-2021]: https://veribom.atlassian.net/browse/VU-2021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VU-2019]: https://veribom.atlassian.net/browse/VU-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ