### PR TITLE
fix: update ir_pse_image default to latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,9 +66,9 @@ inputs:
     required: false
     default: ''
   pse_image_tag:
-    description: 'Tag for invisirisk/pse-proxy image. Defaults to dev-test for backward-compatible intermediate rollout.'
+    description: 'Tag for invisirisk/pse-proxy image. Defaults to latest for backward-compatible intermediate rollout.'
     required: false
-    default: 'dev-test'
+    default: 'latest'
 # Define outputs for the action
 outputs:
   scan_id:

--- a/scripts/mode_setup.sh
+++ b/scripts/mode_setup.sh
@@ -104,7 +104,7 @@ pull_and_start_pse_container() {
   echo "$ECR_TOKEN" | run_with_privilege docker login --username "$ECR_USERNAME" --password-stdin "$ECR_REGISTRY_ID.dkr.ecr.$ECR_REGION.amazonaws.com"
 
 
-  local image_tag="${PSE_IMAGE_TAG:-dev-test}"
+  local image_tag="${PSE_IMAGE_TAG:-latest}"
 
   # Define possible repository paths to try
   local REPO_PATHS=(


### PR DESCRIPTION
This pull request updates the default Docker image tag for the `invisirisk/pse-proxy` container from `dev-test` to `latest` to ensure that the most up-to-date version is used by default. This change is reflected both in the GitHub Action configuration and in the container startup script.

**Default image tag change:**

* Updated the `pse_image_tag` input in `action.yml` to default to `latest` and revised its description accordingly.
* Changed the fallback image tag in the `pull_and_start_pse_container` function in `scripts/mode_setup.sh` from `dev-test` to `latest`.