### PR TITLE
hotfix: backward compatibility for action job status collection using send_job_status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,6 @@ inputs:
     description: 'Enable debug mode for verbose logging'
     required: false
     default: 'false'
-  send_job_status:
-    description: 'Set to true to allow SaaS platform to fetch job status for current action run. Runs automatically during cleanup.'
-    required: false
-    default: 'true'
   mode:
     description: 'The operation mode: "native" (default) downloads and runs the PSE binary directly, "sidecar" pulls and runs the PSE proxy as a Docker container.'
     required: false
@@ -37,10 +33,18 @@ inputs:
     description: 'Set to true to collect dependency graphs during cleanup, false to skip. Default is true if not specified.'
     required: false
     default: ''
+  collect_job_status:
+    description: 'Set to true to collect GitHub Actions workflow status during cleanup, false to skip. Default is true if not specified.'
+    required: false
+    default: 'true'
   workdir:
     description: 'Working directory to use as the project path for dependency graph collection. Defaults to the current directory (pwd) if not specified.'
     required: false
     default: ''
+  send_job_status:
+    description: '[DEPRECATED] GitHub Actions workflow status collection is now handled internally by the action and this input does nothing. Will be removed in a future release.'
+    required: false
+    default: 'false'
   cleanup:
     description: '[DEPRECATED] Cleanup is now handled internally by the action and this input does nothing. Will be removed in a future release.'
     required: false

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { execFileSync } = require('child_process');
-const { buildEnv, getInput, handleDeprecatedCleanupInput, pick, saveState } = require('./utils');
+const { buildEnv, getInput, handleDeprecatedInputs, pick, saveState } = require('./utils');
 
 function runBootstrap(env, execFile = execFileSync) {
   const bootstrapUrl = new URL('/ingestionapi/v1/pse/bootstrap', env.IR_URL);
@@ -89,7 +89,7 @@ function run({ execFile = execFileSync, inputReader = getInput, envSource = proc
 
 if (require.main === module) {
   try {
-    if (!handleDeprecatedCleanupInput()) {
+    if (!handleDeprecatedInputs()) {
       run();
     }
   } catch (error) {

--- a/src/post.js
+++ b/src/post.js
@@ -1,11 +1,11 @@
 const { spawnSync } = require('child_process');
-const { buildEnv, getInput, getState, handleDeprecatedCleanupInput, pick } = require('./utils');
+const { buildEnv, getInput, getState, handleDeprecatedInputs, pick } = require('./utils');
 
 function run(spawn = spawnSync, stdout = process.stdout, stderr = process.stderr) {
   const env = buildEnv({
     IR_URL: pick(getInput('api_url'), process.env.PSE_API_URL),
     IR_TOKEN: pick(getInput('app_token'), process.env.PSE_APP_TOKEN),
-    SEND_JOB_STATUS: getInput('send_job_status') === 'false' ? 'false' : 'true',
+    SEND_JOB_STATUS: getInput('collect_job_status') === 'false' ? 'false' : 'true',
   });
 
   const debug = pick(getInput('debug'), process.env.DEBUG);
@@ -44,7 +44,7 @@ function run(spawn = spawnSync, stdout = process.stdout, stderr = process.stderr
 
 function main(spawn = spawnSync, exit = process.exit, stdout = process.stdout, stderr = process.stderr, stateReader = getState) {
   try {
-    if (handleDeprecatedCleanupInput(true)) {
+    if (handleDeprecatedInputs(true)) {
       return;
     }
     if (stateReader('pse_setup_completed') !== 'true') {

--- a/src/post.test.js
+++ b/src/post.test.js
@@ -43,6 +43,52 @@ test('run streams collector stdout and stderr once', () => {
   assert.equal(stderr, 'cleanup stderr\n');
 });
 
+test('run maps collect_job_status to SEND_JOB_STATUS', () => {
+  let collectorEnv;
+
+  try {
+    process.env.INPUT_COLLECT_JOB_STATUS = 'false';
+    run((cmd, args, options) => {
+      collectorEnv = options.env;
+      return { status: 0, stdout: '', stderr: '' };
+    }, { write: () => {} }, { write: () => {} });
+  } finally {
+    delete process.env.INPUT_COLLECT_JOB_STATUS;
+  }
+
+  assert.equal(collectorEnv.SEND_JOB_STATUS, 'false');
+});
+
+test('main skips cleanup and exits early for deprecated send_job_status input', () => {
+  let called = false;
+
+  const originalWarn = console.warn;
+  let warning = '';
+  console.warn = (message) => {
+    warning = message;
+  };
+
+  try {
+    process.env.STATE_skip_post = 'send_job_status';
+    main(
+      () => {
+        called = true;
+        return { status: 0, stdout: '', stderr: '' };
+      },
+      () => {},
+      { write: () => {} },
+      { write: () => {} },
+      () => 'true',
+    );
+  } finally {
+    console.warn = originalWarn;
+    delete process.env.STATE_skip_post;
+  }
+
+  assert.equal(called, false);
+  assert.match(warning, /send_job_status.*deprecated/i);
+});
+
 test('main fails the post step with the collector exit code', () => {
   let stdout = '';
   let stderr = '';

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const os = require('os');
 
 const DEPRECATED_CLEANUP_MESSAGE = 'The "cleanup" input is deprecated. Cleanup runs automatically through the action post step. Remove the cleanup step from your workflow.';
-const DEPRECATED_SEND_JOB_STATUS_MESSAGE = 'The "send_job_status" input is deprecated. GitHub Actions workflow status collection is now handled internally by the action. Remove the send_job_status step from your workflow.';
+const DEPRECATED_SEND_JOB_STATUS_MESSAGE = 'The "send_job_status" input is deprecated. GitHub Actions workflow status collection is now handled internally by the action. Remove the InvisiRisk\'s Gather Analytics job from your workflow.';
 
 function readNamedValue(prefix, name) {
   const key = `${prefix}_${name.replace(/ /g, '_').replace(/-/g, '_').toUpperCase()}`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const os = require('os');
 
 const DEPRECATED_CLEANUP_MESSAGE = 'The "cleanup" input is deprecated. Cleanup runs automatically through the action post step. Remove the cleanup step from your workflow.';
+const DEPRECATED_SEND_JOB_STATUS_MESSAGE = 'The "send_job_status" input is deprecated. GitHub Actions workflow status collection is now handled internally by the action. Remove the send_job_status step from your workflow.';
 
 function readNamedValue(prefix, name) {
   const key = `${prefix}_${name.replace(/ /g, '_').replace(/-/g, '_').toUpperCase()}`;
@@ -46,16 +47,33 @@ function warn(message, title = 'PSE Action') {
 }
 
 function handleDeprecatedCleanupInput(isPost = false) {
-  const shouldWarn = isPost ? getState('skip_post') === 'true' : getInput('cleanup') === 'true';
+  const shouldWarn = isPost ? getState('skip_post') === 'cleanup' : getInput('cleanup') === 'true';
   if (!shouldWarn) {
     return false;
   }
 
   warn(DEPRECATED_CLEANUP_MESSAGE, 'Deprecated cleanup input');
   if (!isPost) {
-    saveState('skip_post', 'true');
+    saveState('skip_post', 'cleanup');
   }
   return true;
+}
+
+function handleDeprecatedSendJobStatusInput(isPost = false) {
+  const shouldWarn = isPost ? getState('skip_post') === 'send_job_status' : getInput('send_job_status') === 'true';
+  if (!shouldWarn) {
+    return false;
+  }
+
+  warn(DEPRECATED_SEND_JOB_STATUS_MESSAGE, 'Deprecated send_job_status input');
+  if (!isPost) {
+    saveState('skip_post', 'send_job_status');
+  }
+  return true;
+}
+
+function handleDeprecatedInputs(isPost = false) {
+  return handleDeprecatedCleanupInput(isPost) || handleDeprecatedSendJobStatusInput(isPost);
 }
 
 module.exports = {
@@ -63,6 +81,8 @@ module.exports = {
   getState,
   getInput,
   handleDeprecatedCleanupInput,
+  handleDeprecatedInputs,
+  handleDeprecatedSendJobStatusInput,
   pick,
   saveState,
 };


### PR DESCRIPTION
## Summary
  - deprecate `send_job_status` in favor of `collect_job_status`
  - keep GitHub Actions workflow status collection active through `collect_job_status`
  - centralize deprecated-input handling for `cleanup` and `send_job_status`

  ## Changes
  - mark `send_job_status` as deprecated in `action.yml`
  - keep `collect_job_status` as the live flag for `SEND_JOB_STATUS` during cleanup
  - make deprecated `cleanup` and `send_job_status` inputs warn and exit early instead of driving legacy execution paths
  - add test coverage for `collect_job_status` mapping and deprecated `send_job_status` handling