### PR TITLE
Release 07-21

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,6 @@ inputs:
   app_token:
     description: 'Authentication token for the InvisiRisk API. If omitted, the action uses GitHub OIDC to request a runtime token.'
     required: false
-  oidc_exchange_url:
-    description: 'OIDC token exchange endpoint. Defaults to <api_url>/oidc/exchange.'
-    required: false
-    default: ''
-  oidc_audience:
-    description: 'Audience to request for the GitHub Actions OIDC token.'
-    required: false
-    default: 'invisirisk-oidc-validator'
   github_token:
     description: 'GitHub token for API access (auto-populated, no need to set explicitly)'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -11,10 +11,10 @@ inputs:
     required: false
     default: 'https://app.invisirisk.com'
   app_token:
-    description: 'Authentication token for the InvisiRisk API. If omitted, the action uses GitHub OIDC to request a runtime token.'
+    description: 'Authentication token for the InvisiRisk API. If omitted, the action signs in securely with GitHub.'
     required: false
   github_token:
-    description: 'GitHub token for API access (auto-populated, no need to set explicitly)'
+    description: 'GitHub token used to resolve the current numeric workflow ID. Auto-populated; OIDC mode requires actions: read permission.'
     required: false
     default: ${{ github.token }}
   debug:

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,24 @@ inputs:
     required: false
     default: 'https://app.invisirisk.com'
   app_token:
-    description: 'Authentication token for the InvisiRisk API'
-    required: true
+    description: 'Authentication token for the InvisiRisk API. If omitted, the action uses GitHub OIDC to request a runtime token.'
+    required: false
+  project_id:
+    description: 'InvisiRisk project ID used for GitHub OIDC token exchange when app_token is omitted.'
+    required: false
+    default: ''
+  workflow_path:
+    description: 'GitHub Actions workflow path used for GitHub OIDC token exchange when app_token is omitted.'
+    required: false
+    default: ''
+  oidc_exchange_url:
+    description: 'OIDC token exchange endpoint. Defaults to <api_url>/oidc/exchange.'
+    required: false
+    default: ''
+  oidc_audience:
+    description: 'Audience to request for the GitHub Actions OIDC token.'
+    required: false
+    default: 'invisirisk-oidc-validator'
   github_token:
     description: 'GitHub token for API access (auto-populated, no need to set explicitly)'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,6 @@ inputs:
   app_token:
     description: 'Authentication token for the InvisiRisk API. If omitted, the action uses GitHub OIDC to request a runtime token.'
     required: false
-  project_id:
-    description: 'InvisiRisk project ID used for GitHub OIDC token exchange when app_token is omitted.'
-    required: false
-    default: ''
-  workflow_path:
-    description: 'GitHub Actions workflow path used for GitHub OIDC token exchange when app_token is omitted.'
-    required: false
-    default: ''
   oidc_exchange_url:
     description: 'OIDC token exchange endpoint. Defaults to <api_url>/oidc/exchange.'
     required: false

--- a/src/index.js
+++ b/src/index.js
@@ -87,15 +87,41 @@ async function requestGithubOidcToken(
 }
 
 function extractTokenFromExchangeResponse(payload) {
+  const normalizedPayload = unwrapLambdaProxyPayload(payload);
   return pick(
-    payload && payload.api_key,
-    payload && payload.app_token,
-    payload && payload.access_token,
-    payload && payload.token,
-    payload && payload.data && payload.data.api_key,
-    payload && payload.data && payload.data.app_token,
-    payload && payload.data && payload.data.access_token,
-    payload && payload.data && payload.data.token,
+    normalizedPayload && normalizedPayload.api_key,
+    normalizedPayload && normalizedPayload.app_token,
+    normalizedPayload && normalizedPayload.access_token,
+    normalizedPayload && normalizedPayload.token,
+    normalizedPayload && normalizedPayload.data && normalizedPayload.data.api_key,
+    normalizedPayload && normalizedPayload.data && normalizedPayload.data.app_token,
+    normalizedPayload && normalizedPayload.data && normalizedPayload.data.access_token,
+    normalizedPayload && normalizedPayload.data && normalizedPayload.data.token,
+  );
+}
+
+function unwrapLambdaProxyPayload(payload) {
+  if (!payload || typeof payload !== 'object' || typeof payload.body !== 'string') {
+    return payload;
+  }
+
+  try {
+    return JSON.parse(payload.body);
+  } catch (error) {
+    throw new Error('OIDC token exchange returned a Lambda proxy response with a non-JSON body.');
+  }
+}
+
+function getExchangePayloadStatusCode(payload) {
+  const statusCode = payload && Number(payload.statusCode);
+  return Number.isInteger(statusCode) ? statusCode : null;
+}
+
+function getExchangePayloadErrorDetail(payload) {
+  const normalizedPayload = unwrapLambdaProxyPayload(payload);
+  return (
+    normalizedPayload &&
+    (normalizedPayload.detail || normalizedPayload.message || normalizedPayload.error || '')
   );
 }
 
@@ -136,6 +162,11 @@ async function exchangeOidcForToken({
   }
 
   const payload = await parseJsonResponse(response, 'OIDC token exchange');
+  const payloadStatusCode = getExchangePayloadStatusCode(payload);
+  if (payloadStatusCode !== null && (payloadStatusCode < 200 || payloadStatusCode >= 300)) {
+    const detail = getExchangePayloadErrorDetail(payload);
+    throw new Error(`OIDC token exchange failed with status ${payloadStatusCode}${detail ? `: ${detail}` : ''}.`);
+  }
   const token = extractTokenFromExchangeResponse(payload);
   if (!token) {
     throw new Error('OIDC exchange response did not include an API token or access token.');

--- a/src/index.js
+++ b/src/index.js
@@ -13,33 +13,112 @@ function debug(enabled, message) {
   }
 }
 
+class OidcError extends Error {
+  constructor(title, message) {
+    super(message);
+    this.name = 'OidcError';
+    this.title = title;
+  }
+}
+
+function oidcError(title, message) {
+  return new OidcError(title, message);
+}
+
+function escapeWorkflowCommand(value) {
+  return String(value)
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A');
+}
+
+function reportFailure(error, log = console.error) {
+  if (error instanceof OidcError) {
+    log(`::error title=${escapeWorkflowCommand(error.title)}::${escapeWorkflowCommand(error.message)}`);
+    return;
+  }
+  log(`PSE setup failed: ${error.message}`);
+}
+
 function buildOidcExchangeUrl(apiUrl) {
   try {
     return new URL('/oidc/exchange', apiUrl).toString();
-  } catch (error) {
-    throw new Error(`Invalid OIDC exchange URL configuration: ${error.message}`);
+  } catch (_) {
+    throw oidcError(
+      'PSE configuration required',
+      'Secure sign-in is not configured correctly. Contact your PSE administrator.',
+    );
   }
 }
 
-async function parseJsonResponse(response, context) {
+async function parseJsonResponse(response, reference, message) {
   try {
     return await response.json();
-  } catch (error) {
-    throw new Error(`${context} returned a non-JSON response.`);
+  } catch (_) {
+    throw oidcError(reference, message);
   }
 }
 
-async function readErrorDetail(response) {
-  try {
-    const errorPayload = await response.json();
-    return errorPayload.detail || errorPayload.message || errorPayload.error || '';
-  } catch (_) {
-    try {
-      return await response.text();
-    } catch (__) {
-      return '';
-    }
+function githubWorkflowRequestError(status) {
+  if (status === 401 || status === 403) {
+    return oidcError(
+      'PSE requires workflow access',
+      'PSE requires permission to read this workflow run. Add "actions: read" to the workflow permissions, then rerun the workflow.',
+    );
   }
+  if (status === 404) {
+    return oidcError(
+      'PSE could not verify this workflow',
+      'GitHub could not locate the current workflow run. Rerun the workflow; if the issue persists, contact your PSE administrator.',
+    );
+  }
+  if (status === 429 || status >= 500) {
+    return oidcError(
+      'GitHub is temporarily unavailable',
+      'PSE could not verify this workflow with GitHub. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    );
+  }
+  return oidcError(
+    'PSE could not verify this workflow',
+    'PSE could not verify the current workflow run. Retry the workflow; if the issue persists, contact your PSE administrator.',
+  );
+}
+
+function oidcExchangeRequestError(status) {
+  if (status === 401) {
+    return oidcError(
+      'PSE requires secure sign-in access',
+      'GitHub could not verify this workflow for PSE. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
+    );
+  }
+  if (status === 403) {
+    return oidcError(
+      'PSE project connection required',
+      'This repository, branch, or workflow is not connected to an active PSE project. Verify the project mapping and GitHub App installation in PSE, then rerun the workflow.',
+    );
+  }
+  if (status === 404) {
+    return oidcError(
+      'PSE project connection required',
+      'No PSE project connection was found for this workflow. Connect the repository, branch, and workflow to a PSE project, then rerun the workflow.',
+    );
+  }
+  if (status === 429) {
+    return oidcError(
+      'PSE sign-in temporarily unavailable',
+      'PSE cannot accept another secure sign-in request at this time. Retry the workflow shortly.',
+    );
+  }
+  if (status >= 500) {
+    return oidcError(
+      'PSE sign-in temporarily unavailable',
+      'PSE secure sign-in is temporarily unavailable. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    );
+  }
+  return oidcError(
+    'PSE secure sign-in failed',
+    'PSE could not complete secure sign-in. Retry the workflow; if the issue persists, contact your PSE administrator.',
+  );
 }
 
 async function requestGithubOidcToken(
@@ -51,10 +130,16 @@ async function requestGithubOidcToken(
   const requestUrl = envSource.ACTIONS_ID_TOKEN_REQUEST_URL;
   const requestToken = envSource.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
   if (!requestUrl || !requestToken) {
-    throw new Error('GitHub OIDC is unavailable. Set workflow permissions: id-token: write.');
+    throw oidcError(
+      'PSE requires secure sign-in access',
+      'PSE requires permission to verify this workflow with GitHub. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
+    );
   }
   if (!fetchImpl) {
-    throw new Error('Fetch API is unavailable. This action requires Node 20 or newer.');
+    throw oidcError(
+      'PSE secure sign-in unavailable',
+      'This runner does not support PSE secure sign-in. Use a supported GitHub Actions runner or contact your PSE administrator.',
+    );
   }
 
   const separator = requestUrl.includes('?') ? '&' : '?';
@@ -69,21 +154,117 @@ async function requestGithubOidcToken(
         Accept: 'application/json',
       },
     });
-  } catch (error) {
-    throw new Error(`GitHub OIDC token request failed: ${error.message}`);
+  } catch (_) {
+    throw oidcError(
+      'GitHub connection unavailable',
+      'PSE could not reach GitHub for secure sign-in. Verify the runner can connect to GitHub, then rerun the workflow.',
+    );
   }
 
   if (!response.ok) {
-    const detail = await readErrorDetail(response);
-    throw new Error(`GitHub OIDC token request failed with status ${response.status}${detail ? `: ${detail}` : ''}.`);
+    throw oidcError(
+      'PSE requires secure sign-in access',
+      'GitHub did not allow PSE to verify this workflow. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
+    );
   }
 
-  const payload = await parseJsonResponse(response, 'GitHub OIDC token request');
+  const payload = await parseJsonResponse(
+    response,
+    'PSE secure sign-in failed',
+    'GitHub returned an unexpected secure sign-in response. Retry the workflow; if the issue persists, contact your PSE administrator.',
+  );
   if (!payload || typeof payload.value !== 'string' || !payload.value) {
-    throw new Error('GitHub OIDC token response did not include a token value.');
+    throw oidcError(
+      'PSE secure sign-in failed',
+      'GitHub did not complete secure sign-in for this workflow. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    );
   }
   debug(debugEnabled, 'Received GitHub OIDC token.');
   return payload.value;
+}
+
+async function requestGithubWorkflowContext({
+  githubToken,
+  envSource = process.env,
+  fetchImpl = fetch,
+  debugEnabled = false,
+}) {
+  if (!githubToken) {
+    throw oidcError(
+      'PSE requires workflow access',
+      'PSE requires permission to read this workflow run. Add "actions: read" to the workflow permissions, then rerun the workflow.',
+    );
+  }
+  if (!envSource.GITHUB_REPOSITORY || !envSource.GITHUB_RUN_ID) {
+    throw oidcError(
+      'PSE could not verify this workflow',
+      'PSE could not identify the current GitHub Actions run. Ensure PSE is running inside a GitHub Actions workflow.',
+    );
+  }
+  if (!fetchImpl) {
+    throw oidcError(
+      'PSE workflow verification unavailable',
+      'This runner cannot provide the current workflow details. Use a supported GitHub Actions runner or contact your PSE administrator.',
+    );
+  }
+
+  const [owner, repository] = envSource.GITHUB_REPOSITORY.split('/');
+  if (!owner || !repository) {
+    throw oidcError(
+      'PSE could not verify this workflow',
+      'PSE could not identify the current GitHub Actions run. Ensure PSE is running inside a GitHub Actions workflow.',
+    );
+  }
+
+  const apiUrl = pick(envSource.GITHUB_API_URL, 'https://api.github.com').replace(/\/$/, '');
+  const workflowRunUrl = `${apiUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}/actions/runs/${encodeURIComponent(envSource.GITHUB_RUN_ID)}`;
+  debug(debugEnabled, `Requesting GitHub workflow context for run ${envSource.GITHUB_RUN_ID}.`);
+
+  let response;
+  try {
+    response = await fetchImpl(workflowRunUrl, {
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+  } catch (_) {
+    throw oidcError(
+      'GitHub connection unavailable',
+      'PSE could not reach GitHub to verify this workflow. Verify the runner can connect to GitHub, then rerun the workflow.',
+    );
+  }
+
+  if (!response.ok) {
+    throw githubWorkflowRequestError(response.status);
+  }
+
+  const payload = await parseJsonResponse(
+    response,
+    'PSE could not verify this workflow',
+    'GitHub returned an unexpected response while PSE was verifying this workflow. Retry the workflow; if the issue persists, contact your PSE administrator.',
+  );
+  const workflowId = Number(payload && payload.workflow_id);
+  if (!Number.isInteger(workflowId) || workflowId <= 0) {
+    throw oidcError(
+      'PSE could not verify this workflow',
+      'PSE could not identify the current workflow. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    );
+  }
+
+  const branch = payload && typeof payload.head_branch === 'string'
+    ? payload.head_branch.trim()
+    : '';
+  if (!branch) {
+    throw oidcError(
+      'PSE requires a branch-based run',
+      'PSE could not identify a branch for this run. Workflows started from a tag or without a branch are not supported.',
+    );
+  }
+
+  debug(debugEnabled, `Resolved GitHub branch "${branch}" and workflow_id ${workflowId}.`);
+  return { branch, workflowId };
 }
 
 function extractTokenFromExchangeResponse(payload) {
@@ -100,8 +281,11 @@ function unwrapLambdaProxyPayload(payload) {
 
   try {
     return JSON.parse(payload.body);
-  } catch (error) {
-    throw new Error('OIDC token exchange returned a Lambda proxy response with a non-JSON body.');
+  } catch (_) {
+    throw oidcError(
+      'PSE secure sign-in failed',
+      'PSE received an unexpected secure sign-in response. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    );
   }
 }
 
@@ -110,23 +294,32 @@ function getExchangePayloadStatusCode(payload) {
   return Number.isInteger(statusCode) ? statusCode : null;
 }
 
-function getExchangePayloadErrorDetail(payload) {
-  const normalizedPayload = unwrapLambdaProxyPayload(payload);
-  return (
-    normalizedPayload &&
-    (normalizedPayload.detail || normalizedPayload.message || normalizedPayload.error || '')
-  );
-}
-
 async function exchangeOidcForToken({
   exchangeUrl,
   audience,
+  branch,
+  workflowId,
   envSource,
   fetchImpl = fetch,
   debugEnabled = false,
 }) {
   if (!exchangeUrl) {
-    throw new Error('Missing OIDC exchange URL.');
+    throw oidcError(
+      'PSE configuration required',
+      'Secure sign-in is not configured correctly. Contact your PSE administrator.',
+    );
+  }
+  if (!branch) {
+    throw oidcError(
+      'PSE requires a branch-based run',
+      'PSE could not identify a branch for this run. Workflows started from a tag or without a branch are not supported.',
+    );
+  }
+  if (!Number.isInteger(Number(workflowId)) || Number(workflowId) <= 0) {
+    throw oidcError(
+      'PSE could not verify this workflow',
+      'PSE could not identify the current workflow. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    );
   }
 
   const oidcToken = await requestGithubOidcToken(audience, envSource, fetchImpl, debugEnabled);
@@ -142,27 +335,37 @@ async function exchangeOidcForToken({
       },
       body: JSON.stringify({
         oidc_token: oidcToken,
+        branch,
+        workflow_id: Number(workflowId),
       }),
     });
-  } catch (error) {
-    throw new Error(`OIDC token exchange request failed: ${error.message}`);
+  } catch (_) {
+    throw oidcError(
+      'PSE connection unavailable',
+      'The runner could not reach PSE for secure sign-in. Verify the runner network connection, then rerun the workflow.',
+    );
   }
   debug(debugEnabled, `OIDC exchange response status: ${response.status}.`);
 
   if (!response.ok) {
-    const detail = await readErrorDetail(response);
-    throw new Error(`OIDC token exchange failed with status ${response.status}${detail ? `: ${detail}` : ''}.`);
+    throw oidcExchangeRequestError(response.status);
   }
 
-  const payload = await parseJsonResponse(response, 'OIDC token exchange');
+  const payload = await parseJsonResponse(
+    response,
+    'PSE secure sign-in failed',
+    'PSE received an unexpected secure sign-in response. Retry the workflow; if the issue persists, contact your PSE administrator.',
+  );
   const payloadStatusCode = getExchangePayloadStatusCode(payload);
   if (payloadStatusCode !== null && (payloadStatusCode < 200 || payloadStatusCode >= 300)) {
-    const detail = getExchangePayloadErrorDetail(payload);
-    throw new Error(`OIDC token exchange failed with status ${payloadStatusCode}${detail ? `: ${detail}` : ''}.`);
+    throw oidcExchangeRequestError(payloadStatusCode);
   }
   const token = extractTokenFromExchangeResponse(payload);
   if (!token) {
-    throw new Error('OIDC exchange response did not include an API token');
+    throw oidcError(
+      'PSE secure sign-in failed',
+      'PSE secure sign-in did not complete. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    );
   }
   debug(debugEnabled, 'OIDC exchange returned a runtime token.');
   return token;
@@ -252,18 +455,26 @@ async function run({
   }
   const debugEnabled = pick(inputReader('debug'), env.DEBUG, envSource.DEBUG) === 'true';
   if (!env.IR_TOKEN) {
-    info('No API token provided; using GitHub OIDC token exchange.');
+    info('Signing in securely with GitHub...');
     const exchangeUrl = buildOidcExchangeUrl(env.IR_URL);
+    const workflowContext = await requestGithubWorkflowContext({
+      githubToken: env.GITHUB_TOKEN,
+      envSource,
+      fetchImpl,
+      debugEnabled,
+    });
     env.IR_TOKEN = await exchangeOidcForToken({
       exchangeUrl,
       audience: DEFAULT_OIDC_AUDIENCE,
+      branch: workflowContext.branch,
+      workflowId: workflowContext.workflowId,
       envSource,
       fetchImpl,
       debugEnabled,
     });
     maskSecret(env.IR_TOKEN);
     exportVariable('IR_TOKEN', env.IR_TOKEN);
-    info('OIDC exchange succeeded; runtime token exported as IR_TOKEN.');
+    info('Secure sign-in succeeded.');
   } else {
     debug(debugEnabled, 'Using provided API token.');
   }
@@ -281,7 +492,7 @@ if (require.main === module) {
       }
     })
     .catch((error) => {
-      console.error(`PSE setup failed: ${error.message}`);
+      reportFailure(error);
       process.exit(1);
     });
 }
@@ -291,7 +502,9 @@ module.exports = {
   buildOidcExchangeUrl,
   exchangeOidcForToken,
   extractTokenFromExchangeResponse,
+  requestGithubWorkflowContext,
   requestGithubOidcToken,
+  reportFailure,
   runBootstrap,
   run,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 const { execFileSync } = require('child_process');
+const { getRequestErrorMessage, OIDC_MESSAGES } = require('./messages');
 const { buildEnv, exportVariable, getInput, handleDeprecatedInputs, maskSecret, pick, saveState } = require('./utils');
 
 const DEFAULT_OIDC_AUDIENCE = 'invisirisk-oidc-validator';
 
 function info(message) {
-  console.log(`[PSE] ${message}`);
+  console.log(`[BAF] ${message}`);
 }
 
 function debug(enabled, message) {
@@ -25,6 +26,10 @@ function oidcError(title, message) {
   return new OidcError(title, message);
 }
 
+function oidcMessageError({ title, message }) {
+  return oidcError(title, message);
+}
+
 function escapeWorkflowCommand(value) {
   return String(value)
     .replace(/%/g, '%25')
@@ -40,85 +45,31 @@ function reportFailure(error, log = console.error) {
   log(`PSE setup failed: ${error.message}`);
 }
 
-function buildOidcExchangeUrl(apiUrl) {
+function buildOidcExchangeUrl(apiUrl, debugEnabled = false) {
   try {
     return new URL('/oidc/exchange', apiUrl).toString();
-  } catch (_) {
-    throw oidcError(
-      'PSE configuration required',
-      'Secure sign-in is not configured correctly. Contact your PSE administrator.',
-    );
+  } catch (error) {
+    debug(debugEnabled, `Failed to build the OIDC exchange URL: ${error.message}`);
+    throw oidcMessageError(OIDC_MESSAGES.configurationRequired);
   }
 }
 
-async function parseJsonResponse(response, reference, message) {
+async function parseJsonResponse(response, errorMessage, debugEnabled = false) {
   try {
     return await response.json();
-  } catch (_) {
-    throw oidcError(reference, message);
+  } catch (error) {
+    debug(debugEnabled, `Failed to parse JSON response: ${error.message}`);
+    throw oidcMessageError(errorMessage);
   }
 }
 
-function githubWorkflowRequestError(status) {
-  if (status === 401 || status === 403) {
-    return oidcError(
-      'PSE requires workflow access',
-      'PSE requires permission to read this workflow run. Add "actions: read" to the workflow permissions, then rerun the workflow.',
-    );
-  }
-  if (status === 404) {
-    return oidcError(
-      'PSE could not verify this workflow',
-      'GitHub could not locate the current workflow run. Rerun the workflow; if the issue persists, contact your PSE administrator.',
-    );
-  }
-  if (status === 429 || status >= 500) {
-    return oidcError(
-      'GitHub is temporarily unavailable',
-      'PSE could not verify this workflow with GitHub. Retry the workflow; if the issue persists, contact your PSE administrator.',
-    );
-  }
-  return oidcError(
-    'PSE could not verify this workflow',
-    'PSE could not verify the current workflow run. Retry the workflow; if the issue persists, contact your PSE administrator.',
-  );
+function withHttpStatus(message, status) {
+  return `${message} (HTTP status ${status})`;
 }
 
-function oidcExchangeRequestError(status) {
-  if (status === 401) {
-    return oidcError(
-      'PSE requires secure sign-in access',
-      'GitHub could not verify this workflow for PSE. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
-    );
-  }
-  if (status === 403) {
-    return oidcError(
-      'PSE project connection required',
-      'This repository, branch, or workflow is not connected to an active PSE project. Verify the project mapping and GitHub App installation in PSE, then rerun the workflow.',
-    );
-  }
-  if (status === 404) {
-    return oidcError(
-      'PSE project connection required',
-      'No PSE project connection was found for this workflow. Connect the repository, branch, and workflow to a PSE project, then rerun the workflow.',
-    );
-  }
-  if (status === 429) {
-    return oidcError(
-      'PSE sign-in temporarily unavailable',
-      'PSE cannot accept another secure sign-in request at this time. Retry the workflow shortly.',
-    );
-  }
-  if (status >= 500) {
-    return oidcError(
-      'PSE sign-in temporarily unavailable',
-      'PSE secure sign-in is temporarily unavailable. Retry the workflow; if the issue persists, contact your PSE administrator.',
-    );
-  }
-  return oidcError(
-    'PSE secure sign-in failed',
-    'PSE could not complete secure sign-in. Retry the workflow; if the issue persists, contact your PSE administrator.',
-  );
+function handleRequestError(origin, status) {
+  const { title, message } = getRequestErrorMessage(origin, status);
+  return oidcError(title, withHttpStatus(message, status));
 }
 
 async function requestGithubOidcToken(
@@ -130,16 +81,10 @@ async function requestGithubOidcToken(
   const requestUrl = envSource.ACTIONS_ID_TOKEN_REQUEST_URL;
   const requestToken = envSource.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
   if (!requestUrl || !requestToken) {
-    throw oidcError(
-      'PSE requires secure sign-in access',
-      'PSE requires permission to verify this workflow with GitHub. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.github.accessRequired);
   }
   if (!fetchImpl) {
-    throw oidcError(
-      'PSE secure sign-in unavailable',
-      'This runner does not support PSE secure sign-in. Use a supported GitHub Actions runner or contact your PSE administrator.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.github.runnerUnavailable);
   }
 
   const separator = requestUrl.includes('?') ? '&' : '?';
@@ -154,35 +99,35 @@ async function requestGithubOidcToken(
         Accept: 'application/json',
       },
     });
-  } catch (_) {
-    throw oidcError(
-      'GitHub connection unavailable',
-      'PSE could not reach GitHub for secure sign-in. Verify the runner can connect to GitHub, then rerun the workflow.',
-    );
+  } catch (error) {
+    debug(debugEnabled, `GitHub OIDC token request failed: ${error.message}`);
+    throw oidcMessageError(OIDC_MESSAGES.github.connectionUnavailable);
   }
 
   if (!response.ok) {
-    throw oidcError(
-      'PSE requires secure sign-in access',
-      'GitHub did not allow PSE to verify this workflow. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.github.accessDenied);
   }
 
   const payload = await parseJsonResponse(
     response,
-    'PSE secure sign-in failed',
-    'GitHub returned an unexpected secure sign-in response. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    OIDC_MESSAGES.github.invalidResponse,
+    debugEnabled,
   );
   if (!payload || typeof payload.value !== 'string' || !payload.value) {
-    throw oidcError(
-      'PSE secure sign-in failed',
-      'GitHub did not complete secure sign-in for this workflow. Retry the workflow; if the issue persists, contact your PSE administrator.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.github.tokenMissing);
   }
   debug(debugEnabled, 'Received GitHub OIDC token.');
   return payload.value;
 }
 
+/**
+ * Fetches the current GitHub Actions run from the GitHub API and extracts the
+ * source branch and numeric workflow ID. These values identify the workflow to
+ * BAF and are included in the subsequent OIDC token exchange request.
+ *
+ * @returns {Promise<{branch: string, workflowId: number}>} The validated
+ * workflow context required by the OIDC exchange.
+ */
 async function requestGithubWorkflowContext({
   githubToken,
   envSource = process.env,
@@ -190,30 +135,18 @@ async function requestGithubWorkflowContext({
   debugEnabled = false,
 }) {
   if (!githubToken) {
-    throw oidcError(
-      'PSE requires workflow access',
-      'PSE requires permission to read this workflow run. Add "actions: read" to the workflow permissions, then rerun the workflow.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.workflow.accessRequired);
   }
   if (!envSource.GITHUB_REPOSITORY || !envSource.GITHUB_RUN_ID) {
-    throw oidcError(
-      'PSE could not verify this workflow',
-      'PSE could not identify the current GitHub Actions run. Ensure PSE is running inside a GitHub Actions workflow.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.workflow.contextMissing);
   }
   if (!fetchImpl) {
-    throw oidcError(
-      'PSE workflow verification unavailable',
-      'This runner cannot provide the current workflow details. Use a supported GitHub Actions runner or contact your PSE administrator.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.workflow.runnerUnavailable);
   }
 
   const [owner, repository] = envSource.GITHUB_REPOSITORY.split('/');
   if (!owner || !repository) {
-    throw oidcError(
-      'PSE could not verify this workflow',
-      'PSE could not identify the current GitHub Actions run. Ensure PSE is running inside a GitHub Actions workflow.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.workflow.contextMissing);
   }
 
   const apiUrl = pick(envSource.GITHUB_API_URL, 'https://api.github.com').replace(/\/$/, '');
@@ -229,63 +162,54 @@ async function requestGithubWorkflowContext({
         'X-GitHub-Api-Version': '2022-11-28',
       },
     });
-  } catch (_) {
-    throw oidcError(
-      'GitHub connection unavailable',
-      'PSE could not reach GitHub to verify this workflow. Verify the runner can connect to GitHub, then rerun the workflow.',
-    );
+  } catch (error) {
+    debug(debugEnabled, `GitHub workflow context request failed: ${error.message}`);
+    throw oidcMessageError(OIDC_MESSAGES.workflow.connectionUnavailable);
   }
+  debug(debugEnabled, `GitHub workflow context response status: ${response.status}.`);
 
   if (!response.ok) {
-    throw githubWorkflowRequestError(response.status);
+    throw handleRequestError('github', response.status);
   }
 
   const payload = await parseJsonResponse(
     response,
-    'PSE could not verify this workflow',
-    'GitHub returned an unexpected response while PSE was verifying this workflow. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    OIDC_MESSAGES.workflow.invalidResponse,
+    debugEnabled,
   );
   const workflowId = Number(payload && payload.workflow_id);
   if (!Number.isInteger(workflowId) || workflowId <= 0) {
-    throw oidcError(
-      'PSE could not verify this workflow',
-      'PSE could not identify the current workflow. Retry the workflow; if the issue persists, contact your PSE administrator.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.workflow.idMissing);
   }
 
   const branch = payload && typeof payload.head_branch === 'string'
     ? payload.head_branch.trim()
     : '';
   if (!branch) {
-    throw oidcError(
-      'PSE requires a branch-based run',
-      'PSE could not identify a branch for this run. Workflows started from a tag or without a branch are not supported.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.workflow.branchRequired);
   }
 
   debug(debugEnabled, `Resolved GitHub branch "${branch}" and workflow_id ${workflowId}.`);
   return { branch, workflowId };
 }
 
-function extractTokenFromExchangeResponse(payload) {
-  const normalizedPayload = unwrapLambdaProxyPayload(payload);
+function extractTokenFromExchangeResponse(payload, debugEnabled = false) {
+  const normalizedPayload = unwrapLambdaProxyPayload(payload, debugEnabled);
   return normalizedPayload && typeof normalizedPayload.api_key === 'string'
     ? normalizedPayload.api_key.trim()
     : '';
 }
 
-function unwrapLambdaProxyPayload(payload) {
+function unwrapLambdaProxyPayload(payload, debugEnabled = false) {
   if (!payload || typeof payload !== 'object' || typeof payload.body !== 'string') {
     return payload;
   }
 
   try {
     return JSON.parse(payload.body);
-  } catch (_) {
-    throw oidcError(
-      'PSE secure sign-in failed',
-      'PSE received an unexpected secure sign-in response. Retry the workflow; if the issue persists, contact your PSE administrator.',
-    );
+  } catch (error) {
+    debug(debugEnabled, `Failed to parse OIDC Lambda proxy response: ${error.message}`);
+    throw oidcMessageError(OIDC_MESSAGES.exchange.invalidResponse);
   }
 }
 
@@ -304,22 +228,13 @@ async function exchangeOidcForToken({
   debugEnabled = false,
 }) {
   if (!exchangeUrl) {
-    throw oidcError(
-      'PSE configuration required',
-      'Secure sign-in is not configured correctly. Contact your PSE administrator.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.configurationRequired);
   }
   if (!branch) {
-    throw oidcError(
-      'PSE requires a branch-based run',
-      'PSE could not identify a branch for this run. Workflows started from a tag or without a branch are not supported.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.workflow.branchRequired);
   }
   if (!Number.isInteger(Number(workflowId)) || Number(workflowId) <= 0) {
-    throw oidcError(
-      'PSE could not verify this workflow',
-      'PSE could not identify the current workflow. Retry the workflow; if the issue persists, contact your PSE administrator.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.workflow.idMissing);
   }
 
   const oidcToken = await requestGithubOidcToken(audience, envSource, fetchImpl, debugEnabled);
@@ -339,33 +254,28 @@ async function exchangeOidcForToken({
         workflow_id: Number(workflowId),
       }),
     });
-  } catch (_) {
-    throw oidcError(
-      'PSE connection unavailable',
-      'The runner could not reach PSE for secure sign-in. Verify the runner network connection, then rerun the workflow.',
-    );
+  } catch (error) {
+    debug(debugEnabled, `OIDC token exchange request failed: ${error.message}`);
+    throw oidcMessageError(OIDC_MESSAGES.exchange.connectionUnavailable);
   }
   debug(debugEnabled, `OIDC exchange response status: ${response.status}.`);
 
   if (!response.ok) {
-    throw oidcExchangeRequestError(response.status);
+    throw handleRequestError('oidc', response.status);
   }
 
   const payload = await parseJsonResponse(
     response,
-    'PSE secure sign-in failed',
-    'PSE received an unexpected secure sign-in response. Retry the workflow; if the issue persists, contact your PSE administrator.',
+    OIDC_MESSAGES.exchange.invalidResponse,
+    debugEnabled,
   );
   const payloadStatusCode = getExchangePayloadStatusCode(payload);
   if (payloadStatusCode !== null && (payloadStatusCode < 200 || payloadStatusCode >= 300)) {
-    throw oidcExchangeRequestError(payloadStatusCode);
+    throw handleRequestError('oidc', payloadStatusCode);
   }
-  const token = extractTokenFromExchangeResponse(payload);
+  const token = extractTokenFromExchangeResponse(payload, debugEnabled);
   if (!token) {
-    throw oidcError(
-      'PSE secure sign-in failed',
-      'PSE secure sign-in did not complete. Retry the workflow; if the issue persists, contact your PSE administrator.',
-    );
+    throw oidcMessageError(OIDC_MESSAGES.exchange.tokenMissing);
   }
   debug(debugEnabled, 'OIDC exchange returned a runtime token.');
   return token;
@@ -456,7 +366,7 @@ async function run({
   const debugEnabled = pick(inputReader('debug'), env.DEBUG, envSource.DEBUG) === 'true';
   if (!env.IR_TOKEN) {
     info('Signing in securely with GitHub...');
-    const exchangeUrl = buildOidcExchangeUrl(env.IR_URL);
+    const exchangeUrl = buildOidcExchangeUrl(env.IR_URL, debugEnabled);
     const workflowContext = await requestGithubWorkflowContext({
       githubToken: env.GITHUB_TOKEN,
       envSource,
@@ -476,7 +386,7 @@ async function run({
     exportVariable('IR_TOKEN', env.IR_TOKEN);
     info('Secure sign-in succeeded.');
   } else {
-    debug(debugEnabled, 'Using provided API token.');
+    info(debugEnabled, 'Using provided API token.');
   }
 
   console.log(`Running PSE setup in ${env.MODE || 'native'} mode...`);

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,9 @@ function debug(enabled, message) {
   }
 }
 
-function buildOidcExchangeUrl(apiUrl, configuredUrl) {
+function buildOidcExchangeUrl(apiUrl) {
   try {
-    return new URL(configuredUrl || '/oidc/exchange', apiUrl).toString();
+    return new URL('/oidc/exchange', apiUrl).toString();
   } catch (error) {
     throw new Error(`Invalid OIDC exchange URL configuration: ${error.message}`);
   }
@@ -88,16 +88,9 @@ async function requestGithubOidcToken(
 
 function extractTokenFromExchangeResponse(payload) {
   const normalizedPayload = unwrapLambdaProxyPayload(payload);
-  return pick(
-    normalizedPayload && normalizedPayload.api_key,
-    normalizedPayload && normalizedPayload.app_token,
-    normalizedPayload && normalizedPayload.access_token,
-    normalizedPayload && normalizedPayload.token,
-    normalizedPayload && normalizedPayload.data && normalizedPayload.data.api_key,
-    normalizedPayload && normalizedPayload.data && normalizedPayload.data.app_token,
-    normalizedPayload && normalizedPayload.data && normalizedPayload.data.access_token,
-    normalizedPayload && normalizedPayload.data && normalizedPayload.data.token,
-  );
+  return normalizedPayload && typeof normalizedPayload.api_key === 'string'
+    ? normalizedPayload.api_key.trim()
+    : '';
 }
 
 function unwrapLambdaProxyPayload(payload) {
@@ -169,7 +162,7 @@ async function exchangeOidcForToken({
   }
   const token = extractTokenFromExchangeResponse(payload);
   if (!token) {
-    throw new Error('OIDC exchange response did not include an API token or access token.');
+    throw new Error('OIDC exchange response did not include an API token');
   }
   debug(debugEnabled, 'OIDC exchange returned a runtime token.');
   return token;
@@ -190,9 +183,9 @@ set -euo pipefail
 if ! curl -sSf -H "x-api-key: $IR_TOKEN" "$BOOTSTRAP_URL" | bash; then
   http_status=$(curl -sS -o /dev/null -w "%{http_code}" -H "x-api-key: $IR_TOKEN" "$BOOTSTRAP_URL" || true)
   if [ "$http_status" = "401" ]; then
-    echo "::error title=PSE bootstrap unauthorized::Unauthorized request from InvisiRisk bootstrap API. Verify app_token is valid for $IR_URL."
+    echo "::error title=PSE bootstrap unauthorized::Unauthorized request from InvisiRisk bootstrap API. Verify the authentication token is valid for $IR_URL."
   elif [ "$http_status" = "403" ]; then
-    echo "::error title=PSE bootstrap forbidden::Forbidden request from InvisiRisk bootstrap API. Verify app_token is authorized for $IR_URL and has access to the target project."
+    echo "::error title=PSE bootstrap forbidden::Forbidden request from InvisiRisk bootstrap API. Verify the authentication token is authorized for $IR_URL and has access to the target project."
   fi
   exit 1
 fi
@@ -260,11 +253,10 @@ async function run({
   const debugEnabled = pick(inputReader('debug'), env.DEBUG, envSource.DEBUG) === 'true';
   if (!env.IR_TOKEN) {
     info('No API token provided; using GitHub OIDC token exchange.');
-    const audience = pick(inputReader('oidc_audience'), envSource.GITHUB_OIDC_AUDIENCE, DEFAULT_OIDC_AUDIENCE);
-    const exchangeUrl = buildOidcExchangeUrl(env.IR_URL, pick(inputReader('oidc_exchange_url')));
+    const exchangeUrl = buildOidcExchangeUrl(env.IR_URL);
     env.IR_TOKEN = await exchangeOidcForToken({
       exchangeUrl,
-      audience,
+      audience: DEFAULT_OIDC_AUDIENCE,
       envSource,
       fetchImpl,
       debugEnabled,

--- a/src/index.js
+++ b/src/index.js
@@ -100,27 +100,18 @@ function extractTokenFromExchangeResponse(payload) {
 }
 
 async function exchangeOidcForToken({
-  apiUrl,
   exchangeUrl,
   audience,
-  projectId,
-  workflowPath,
   envSource,
   fetchImpl = fetch,
   debugEnabled = false,
 }) {
-  if (!projectId) {
-    throw new Error('Missing required input: project_id when app_token is not provided');
-  }
   if (!exchangeUrl) {
     throw new Error('Missing OIDC exchange URL.');
   }
 
   const oidcToken = await requestGithubOidcToken(audience, envSource, fetchImpl, debugEnabled);
-  debug(
-    debugEnabled,
-    `Exchanging GitHub OIDC token at ${exchangeUrl} for project_id=${projectId}${workflowPath ? ` workflow_path=${workflowPath}` : ''}.`,
-  );
+  debug(debugEnabled, `Exchanging GitHub OIDC token at ${exchangeUrl}.`);
 
   let response;
   try {
@@ -131,11 +122,7 @@ async function exchangeOidcForToken({
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        api_url: apiUrl,
-        project_id: projectId,
-        workflow_path: workflowPath || '',
         oidc_token: oidcToken,
-        audience,
       }),
     });
   } catch (error) {
@@ -245,11 +232,8 @@ async function run({
     const audience = pick(inputReader('oidc_audience'), envSource.GITHUB_OIDC_AUDIENCE, DEFAULT_OIDC_AUDIENCE);
     const exchangeUrl = buildOidcExchangeUrl(env.IR_URL, pick(inputReader('oidc_exchange_url')));
     env.IR_TOKEN = await exchangeOidcForToken({
-      apiUrl: env.IR_URL,
       exchangeUrl,
       audience,
-      projectId: pick(inputReader('project_id'), envSource.PSE_PROJECT_ID, envSource.PROJECT_ID),
-      workflowPath: pick(inputReader('workflow_path'), envSource.PSE_WORKFLOW_PATH),
       envSource,
       fetchImpl,
       debugEnabled,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,161 @@
 const { execFileSync } = require('child_process');
-const { buildEnv, getInput, handleDeprecatedInputs, pick, saveState } = require('./utils');
+const { buildEnv, exportVariable, getInput, handleDeprecatedInputs, maskSecret, pick, saveState } = require('./utils');
+
+const DEFAULT_OIDC_AUDIENCE = 'invisirisk-oidc-validator';
+
+function info(message) {
+  console.log(`[PSE] ${message}`);
+}
+
+function debug(enabled, message) {
+  if (enabled) {
+    console.log(`::debug::${message}`);
+  }
+}
+
+function buildOidcExchangeUrl(apiUrl, configuredUrl) {
+  try {
+    return new URL(configuredUrl || '/oidc/exchange', apiUrl).toString();
+  } catch (error) {
+    throw new Error(`Invalid OIDC exchange URL configuration: ${error.message}`);
+  }
+}
+
+async function parseJsonResponse(response, context) {
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new Error(`${context} returned a non-JSON response.`);
+  }
+}
+
+async function readErrorDetail(response) {
+  try {
+    const errorPayload = await response.json();
+    return errorPayload.detail || errorPayload.message || errorPayload.error || '';
+  } catch (_) {
+    try {
+      return await response.text();
+    } catch (__) {
+      return '';
+    }
+  }
+}
+
+async function requestGithubOidcToken(
+  audience,
+  envSource = process.env,
+  fetchImpl = fetch,
+  debugEnabled = false,
+) {
+  const requestUrl = envSource.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const requestToken = envSource.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  if (!requestUrl || !requestToken) {
+    throw new Error('GitHub OIDC is unavailable. Set workflow permissions: id-token: write.');
+  }
+  if (!fetchImpl) {
+    throw new Error('Fetch API is unavailable. This action requires Node 20 or newer.');
+  }
+
+  const separator = requestUrl.includes('?') ? '&' : '?';
+  const url = `${requestUrl}${separator}audience=${encodeURIComponent(audience)}`;
+  debug(debugEnabled, `Requesting GitHub OIDC token with audience "${audience}".`);
+
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      headers: {
+        Authorization: `Bearer ${requestToken}`,
+        Accept: 'application/json',
+      },
+    });
+  } catch (error) {
+    throw new Error(`GitHub OIDC token request failed: ${error.message}`);
+  }
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new Error(`GitHub OIDC token request failed with status ${response.status}${detail ? `: ${detail}` : ''}.`);
+  }
+
+  const payload = await parseJsonResponse(response, 'GitHub OIDC token request');
+  if (!payload || typeof payload.value !== 'string' || !payload.value) {
+    throw new Error('GitHub OIDC token response did not include a token value.');
+  }
+  debug(debugEnabled, 'Received GitHub OIDC token.');
+  return payload.value;
+}
+
+function extractTokenFromExchangeResponse(payload) {
+  return pick(
+    payload && payload.api_key,
+    payload && payload.app_token,
+    payload && payload.access_token,
+    payload && payload.token,
+    payload && payload.data && payload.data.api_key,
+    payload && payload.data && payload.data.app_token,
+    payload && payload.data && payload.data.access_token,
+    payload && payload.data && payload.data.token,
+  );
+}
+
+async function exchangeOidcForToken({
+  apiUrl,
+  exchangeUrl,
+  audience,
+  projectId,
+  workflowPath,
+  envSource,
+  fetchImpl = fetch,
+  debugEnabled = false,
+}) {
+  if (!projectId) {
+    throw new Error('Missing required input: project_id when app_token is not provided');
+  }
+  if (!exchangeUrl) {
+    throw new Error('Missing OIDC exchange URL.');
+  }
+
+  const oidcToken = await requestGithubOidcToken(audience, envSource, fetchImpl, debugEnabled);
+  debug(
+    debugEnabled,
+    `Exchanging GitHub OIDC token at ${exchangeUrl} for project_id=${projectId}${workflowPath ? ` workflow_path=${workflowPath}` : ''}.`,
+  );
+
+  let response;
+  try {
+    response = await fetchImpl(exchangeUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        api_url: apiUrl,
+        project_id: projectId,
+        workflow_path: workflowPath || '',
+        oidc_token: oidcToken,
+        audience,
+      }),
+    });
+  } catch (error) {
+    throw new Error(`OIDC token exchange request failed: ${error.message}`);
+  }
+  debug(debugEnabled, `OIDC exchange response status: ${response.status}.`);
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new Error(`OIDC token exchange failed with status ${response.status}${detail ? `: ${detail}` : ''}.`);
+  }
+
+  const payload = await parseJsonResponse(response, 'OIDC token exchange');
+  const token = extractTokenFromExchangeResponse(payload);
+  if (!token) {
+    throw new Error('OIDC exchange response did not include an API token or access token.');
+  }
+  debug(debugEnabled, 'OIDC exchange returned a runtime token.');
+  return token;
+}
 
 function runBootstrap(env, execFile = execFileSync) {
   const bootstrapUrl = new URL('/ingestionapi/v1/pse/bootstrap', env.IR_URL);
@@ -72,14 +228,37 @@ function buildRuntimeEnv(inputReader = getInput, envSource = process.env) {
   return env;
 }
 
-function run({ execFile = execFileSync, inputReader = getInput, envSource = process.env } = {}) {
+async function run({
+  execFile = execFileSync,
+  inputReader = getInput,
+  envSource = process.env,
+  fetchImpl = fetch,
+} = {}) {
   const env = buildRuntimeEnv(inputReader, envSource);
 
   if (!env.IR_URL) {
     throw new Error('Missing required input: api_url');
   }
+  const debugEnabled = pick(inputReader('debug'), env.DEBUG, envSource.DEBUG) === 'true';
   if (!env.IR_TOKEN) {
-    throw new Error('Missing required input: app_token (or IR_TOKEN/APP_TOKEN environment variable)');
+    info('No API token provided; using GitHub OIDC token exchange.');
+    const audience = pick(inputReader('oidc_audience'), envSource.GITHUB_OIDC_AUDIENCE, DEFAULT_OIDC_AUDIENCE);
+    const exchangeUrl = buildOidcExchangeUrl(env.IR_URL, pick(inputReader('oidc_exchange_url')));
+    env.IR_TOKEN = await exchangeOidcForToken({
+      apiUrl: env.IR_URL,
+      exchangeUrl,
+      audience,
+      projectId: pick(inputReader('project_id'), envSource.PSE_PROJECT_ID, envSource.PROJECT_ID),
+      workflowPath: pick(inputReader('workflow_path'), envSource.PSE_WORKFLOW_PATH),
+      envSource,
+      fetchImpl,
+      debugEnabled,
+    });
+    maskSecret(env.IR_TOKEN);
+    exportVariable('IR_TOKEN', env.IR_TOKEN);
+    info('OIDC exchange succeeded; runtime token exported as IR_TOKEN.');
+  } else {
+    debug(debugEnabled, 'Using provided API token.');
   }
 
   console.log(`Running PSE setup in ${env.MODE || 'native'} mode...`);
@@ -88,18 +267,24 @@ function run({ execFile = execFileSync, inputReader = getInput, envSource = proc
 }
 
 if (require.main === module) {
-  try {
-    if (!handleDeprecatedInputs()) {
-      run();
-    }
-  } catch (error) {
-    console.error(`PSE setup failed: ${error.message}`);
-    process.exit(1);
-  }
+  Promise.resolve()
+    .then(async () => {
+      if (!handleDeprecatedInputs()) {
+        await run();
+      }
+    })
+    .catch((error) => {
+      console.error(`PSE setup failed: ${error.message}`);
+      process.exit(1);
+    });
 }
 
 module.exports = {
   buildRuntimeEnv,
+  buildOidcExchangeUrl,
+  exchangeOidcForToken,
+  extractTokenFromExchangeResponse,
+  requestGithubOidcToken,
   runBootstrap,
   run,
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,7 +3,13 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { buildOidcExchangeUrl, exchangeOidcForToken, run, runBootstrap } = require('./index');
+const {
+  buildOidcExchangeUrl,
+  exchangeOidcForToken,
+  extractTokenFromExchangeResponse,
+  run,
+  runBootstrap,
+} = require('./index');
 
 test('buildOidcExchangeUrl defaults to /oidc/exchange', () => {
   assert.equal(
@@ -176,6 +182,20 @@ test('run exchanges GitHub OIDC for token when app_token is missing', async () =
   assert.match(fs.readFileSync(githubEnvFile, 'utf8'), /IR_TOKEN=exchanged-runtime-token/);
 });
 
+test('extractTokenFromExchangeResponse handles Lambda proxy response body', () => {
+  const token = extractTokenFromExchangeResponse({
+    statusCode: 200,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      success: true,
+      project_id: '0ed5e5c5-823c-4d5c-bafa-d5962ee4738c',
+      api_key: 'lambda-proxy-api-key',
+    }),
+  });
+
+  assert.equal(token, 'lambda-proxy-api-key');
+});
+
 test('run uses GITHUB_OIDC_AUDIENCE when oidc_audience input is missing', async () => {
   const inputs = {
     api_url: 'https://ir.example',
@@ -279,6 +299,42 @@ test('exchangeOidcForToken includes exchange failure detail', async () => {
       },
     });
   }, /OIDC token exchange failed with status 403: repository is not mapped to project/);
+});
+
+test('exchangeOidcForToken rejects Lambda proxy error response', async () => {
+  let callCount = 0;
+
+  await assert.rejects(async () => {
+    await exchangeOidcForToken({
+      exchangeUrl: 'https://ir.example/oidc/exchange',
+      audience: 'invisirisk-oidc-validator',
+      envSource: {
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
+      },
+      fetchImpl: async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ value: 'github-oidc-token' }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            statusCode: 403,
+            body: JSON.stringify({
+              success: false,
+              message: 'No active repository mapping found for repository',
+            }),
+          }),
+        };
+      },
+    });
+  }, /OIDC token exchange failed with status 403: No active repository mapping found for repository/);
 });
 
 test('exchangeOidcForToken rejects non-JSON exchange response', async () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -125,8 +125,6 @@ test('run exchanges GitHub OIDC for token when app_token is missing', async () =
   const inputs = {
     api_url: 'https://ir.example',
     app_token: '',
-    oidc_exchange_url: 'https://auth.example/oidc/exchange',
-    oidc_audience: 'invisirisk-oidc-validator',
     debug: 'false',
     mode: 'native',
     github_token: '',
@@ -174,7 +172,7 @@ test('run exchanges GitHub OIDC for token when app_token is missing', async () =
   assert.equal(calls.length, 2);
   assert.match(calls[0].url, /audience=invisirisk-oidc-validator/);
   assert.equal(calls[0].options.headers.Authorization, 'Bearer github-request-token');
-  assert.equal(calls[1].url, 'https://auth.example/oidc/exchange');
+  assert.equal(calls[1].url, 'https://ir.example/oidc/exchange');
   assert.deepEqual(JSON.parse(calls[1].options.body), {
     oidc_token: 'github-oidc-token',
   });
@@ -196,42 +194,9 @@ test('extractTokenFromExchangeResponse handles Lambda proxy response body', () =
   assert.equal(token, 'lambda-proxy-api-key');
 });
 
-test('run uses GITHUB_OIDC_AUDIENCE when oidc_audience input is missing', async () => {
-  const inputs = {
-    api_url: 'https://ir.example',
-    app_token: '',
-    debug: 'false',
-    mode: 'native',
-    github_token: '',
-  };
-  const calls = [];
-
-  await run({
-    execFile: () => {},
-    inputReader: (name) => inputs[name] || '',
-    envSource: {
-      ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
-      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
-      GITHUB_OIDC_AUDIENCE: 'invisirisk-oidc-validator',
-    },
-    fetchImpl: async (url) => {
-      calls.push(url);
-      if (url.startsWith('https://token.actions.githubusercontent.com/id-token')) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ value: 'github-oidc-token' }),
-        };
-      }
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ api_key: 'exchanged-runtime-token' }),
-      };
-    },
-  });
-
-  assert.match(calls[0], /audience=invisirisk-oidc-validator/);
+test('extractTokenFromExchangeResponse only accepts api_key', () => {
+  assert.equal(extractTokenFromExchangeResponse({ access_token: 'ignored-token' }), '');
+  assert.equal(extractTokenFromExchangeResponse({ data: { api_key: 'ignored-token' } }), '');
 });
 
 test('run throws helpful error when api_url is missing', async () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -65,6 +65,50 @@ test('requestGithubWorkflowContext rejects runs without head_branch', async () =
   }, /could not identify a branch.*tag or without a branch are not supported/);
 });
 
+test('requestGithubWorkflowContext includes the GitHub HTTP status in request errors', async () => {
+  await assert.rejects(async () => {
+    await requestGithubWorkflowContext({
+      githubToken: 'github-api-token',
+      envSource: {
+        GITHUB_REPOSITORY: 'invisirisk/pse-action',
+        GITHUB_RUN_ID: '987654',
+      },
+      fetchImpl: async () => ({ ok: false, status: 403 }),
+    });
+  }, /HTTP status 403/);
+});
+
+test('requestGithubWorkflowContext logs request exceptions only at debug level', async () => {
+  const messages = [];
+  const originalLog = console.log;
+  console.log = (message) => messages.push(message);
+
+  try {
+    for (const debugEnabled of [false, true]) {
+      await assert.rejects(async () => {
+        await requestGithubWorkflowContext({
+          githubToken: 'github-api-token',
+          envSource: {
+            GITHUB_REPOSITORY: 'invisirisk/pse-action',
+            GITHUB_RUN_ID: '987654',
+          },
+          fetchImpl: async () => {
+            throw new Error('socket closed unexpectedly');
+          },
+          debugEnabled,
+        });
+      }, /could not reach GitHub/);
+    }
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(
+    messages.filter((message) => message === '::debug::GitHub workflow context request failed: socket closed unexpectedly').length,
+    1,
+  );
+});
+
 test('requestGithubOidcToken explains how to enable secure sign-in', async () => {
   await assert.rejects(async () => {
     await requestGithubOidcToken('invisirisk-oidc-validator', {});
@@ -83,9 +127,9 @@ test('reportFailure creates a clear GitHub error annotation without a public err
   reportFailure(oidcFailure, (message) => messages.push(message));
 
   assert.equal(messages.length, 1);
-  assert.match(messages[0], /^::error title=PSE requires secure sign-in access::/);
+  assert.match(messages[0], /^::error title=BAF requires secure sign-in access::/);
   assert.match(messages[0], /Add "id-token: write" to the workflow permissions/);
-  assert.doesNotMatch(messages[0], /PSE-OIDC|Reference:/);
+  assert.doesNotMatch(messages[0], /BAF-OIDC|Reference:/);
 });
 
 test('runBootstrap sets mode to native for docker-intercept or missing MODE', () => {
@@ -189,6 +233,34 @@ test('run resolves token from env fallback', async () => {
   assert.equal(execCall[2].env.IR_TOKEN, 'fallback-token');
   assert.equal(execCall[2].env.PSE_IMAGE_TAG, 'latest');
   assert.equal(execCall[2].env.GITHUB_TOKEN, 'default-gh-token');
+});
+
+test('run logs use of a provided API token only at debug level', async () => {
+  const messages = [];
+  const originalLog = console.log;
+  console.log = (message) => messages.push(message);
+
+  try {
+    for (const debugEnabled of ['false', 'true']) {
+      await run({
+        execFile: () => {},
+        inputReader: (name) => ({
+          api_url: 'https://ir.example',
+          app_token: 'provided-token',
+          debug: debugEnabled,
+          mode: 'native',
+        })[name] || '',
+        envSource: {},
+      });
+    }
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(
+    messages.filter((message) => message === '::debug::Using provided API token.').length,
+    1,
+  );
 });
 
 test('run exchanges GitHub OIDC for token when app_token is missing', async () => {
@@ -349,9 +421,9 @@ test('exchangeOidcForToken explains an inactive project connection without expos
       },
     });
   }, (error) => {
-    assert.match(error.message, /not connected to an active PSE project/);
+    assert.match(error.message, /not connected to an active BAF project/);
     assert.doesNotMatch(error.message, /repository is not mapped to project/);
-    assert.doesNotMatch(error.message, /403/);
+    assert.match(error.message, /HTTP status 403/);
     return true;
   });
 });
@@ -392,9 +464,9 @@ test('exchangeOidcForToken normalizes a Lambda proxy error for the user', async 
       },
     });
   }, (error) => {
-    assert.match(error.message, /not connected to an active PSE project/);
+    assert.match(error.message, /not connected to an active BAF project/);
     assert.doesNotMatch(error.message, /No active repository mapping/);
-    assert.doesNotMatch(error.message, /403/);
+    assert.match(error.message, /HTTP status 403/);
     return true;
   });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,16 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { run, runBootstrap } = require('./index');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { buildOidcExchangeUrl, exchangeOidcForToken, run, runBootstrap } = require('./index');
+
+test('buildOidcExchangeUrl defaults to /oidc/exchange', () => {
+  assert.equal(
+    buildOidcExchangeUrl('https://ir.example'),
+    'https://ir.example/oidc/exchange',
+  );
+});
 
 test('runBootstrap sets mode to native for docker-intercept or missing MODE', () => {
   // MODE is docker-intercept
@@ -46,7 +56,7 @@ test('runBootstrap sets mode to native for docker-intercept or missing MODE', ()
   assert.ok(called);
 });
 
-test('run passes pse_image_tag through to bootstrap environment', () => {
+test('run passes pse_image_tag through to bootstrap environment', async () => {
   const inputs = {
     api_url: 'https://ir.example',
     app_token: 'token',
@@ -59,7 +69,7 @@ test('run passes pse_image_tag through to bootstrap environment', () => {
   };
   let execCall;
 
-  run({
+  await run({
     execFile: (...args) => {
       execCall = args;
     },
@@ -79,7 +89,7 @@ test('run passes pse_image_tag through to bootstrap environment', () => {
   assert.doesNotMatch(execCall[2].env.BOOTSTRAP_URL, /ir_token=/);
 });
 
-test('run resolves token from env fallback', () => {
+test('run resolves token from env fallback', async () => {
   const inputs = {
     api_url: 'https://ir.example',
     app_token: '',
@@ -92,7 +102,7 @@ test('run resolves token from env fallback', () => {
   };
   let execCall;
 
-  run({
+  await run({
     execFile: (...args) => {
       execCall = args;
     },
@@ -105,9 +115,115 @@ test('run resolves token from env fallback', () => {
   assert.equal(execCall[2].env.GITHUB_TOKEN, 'default-gh-token');
 });
 
-test('run throws helpful error when api_url is missing', () => {
-  assert.throws(() => {
-    run({
+test('run exchanges GitHub OIDC for token when app_token is missing', async () => {
+  const inputs = {
+    api_url: 'https://ir.example',
+    app_token: '',
+    project_id: 'project-123',
+    workflow_path: '.github/workflows/build.yml',
+    oidc_exchange_url: 'https://auth.example/oidc/exchange',
+    oidc_audience: 'invisirisk-oidc-validator',
+    debug: 'false',
+    mode: 'native',
+    github_token: '',
+  };
+  const githubEnvFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'pse-action-')), 'env');
+  const originalGithubEnv = process.env.GITHUB_ENV;
+  process.env.GITHUB_ENV = githubEnvFile;
+  const calls = [];
+  let execCall;
+
+  try {
+    await run({
+      execFile: (...args) => {
+        execCall = args;
+      },
+      inputReader: (name) => inputs[name] || '',
+      envSource: {
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
+      },
+      fetchImpl: async (url, options) => {
+        calls.push({ url, options });
+        if (url.startsWith('https://token.actions.githubusercontent.com/id-token')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ value: 'github-oidc-token' }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ api_key: 'exchanged-runtime-token' }),
+        };
+      },
+    });
+  } finally {
+    if (originalGithubEnv === undefined) {
+      delete process.env.GITHUB_ENV;
+    } else {
+      process.env.GITHUB_ENV = originalGithubEnv;
+    }
+  }
+
+  assert.equal(calls.length, 2);
+  assert.match(calls[0].url, /audience=invisirisk-oidc-validator/);
+  assert.equal(calls[0].options.headers.Authorization, 'Bearer github-request-token');
+  assert.equal(calls[1].url, 'https://auth.example/oidc/exchange');
+  assert.deepEqual(JSON.parse(calls[1].options.body), {
+    api_url: 'https://ir.example',
+    project_id: 'project-123',
+    workflow_path: '.github/workflows/build.yml',
+    oidc_token: 'github-oidc-token',
+    audience: 'invisirisk-oidc-validator',
+  });
+  assert.equal(execCall[2].env.IR_TOKEN, 'exchanged-runtime-token');
+  assert.match(fs.readFileSync(githubEnvFile, 'utf8'), /IR_TOKEN=exchanged-runtime-token/);
+});
+
+test('run uses GITHUB_OIDC_AUDIENCE when oidc_audience input is missing', async () => {
+  const inputs = {
+    api_url: 'https://ir.example',
+    app_token: '',
+    project_id: 'project-123',
+    debug: 'false',
+    mode: 'native',
+    github_token: '',
+  };
+  const calls = [];
+
+  await run({
+    execFile: () => {},
+    inputReader: (name) => inputs[name] || '',
+    envSource: {
+      ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
+      GITHUB_OIDC_AUDIENCE: 'invisirisk-oidc-validator',
+    },
+    fetchImpl: async (url) => {
+      calls.push(url);
+      if (url.startsWith('https://token.actions.githubusercontent.com/id-token')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ value: 'github-oidc-token' }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ api_key: 'exchanged-runtime-token' }),
+      };
+    },
+  });
+
+  assert.match(calls[0], /audience=invisirisk-oidc-validator/);
+});
+
+test('run throws helpful error when api_url is missing', async () => {
+  await assert.rejects(async () => {
+    await run({
       inputReader: (name) => {
         const inputs = {
           api_url: '',
@@ -125,9 +241,9 @@ test('run throws helpful error when api_url is missing', () => {
   }, /Missing required input: api_url/);
 });
 
-test('run throws helpful error when token is missing', () => {
-  assert.throws(() => {
-    run({
+test('run throws helpful error when token and project_id are missing', async () => {
+  await assert.rejects(async () => {
+    await run({
       inputReader: (name) => {
         const inputs = {
           api_url: 'https://ir.example',
@@ -143,5 +259,91 @@ test('run throws helpful error when token is missing', () => {
       },
       envSource: {},
     });
-  }, /Missing required input: app_token/);
+  }, /Missing required input: project_id/);
+});
+
+test('run throws helpful error when GitHub OIDC environment is unavailable', async () => {
+  await assert.rejects(async () => {
+    await run({
+      inputReader: (name) => {
+        const inputs = {
+          api_url: 'https://ir.example',
+          app_token: '',
+          project_id: 'project-123',
+          debug: 'false',
+          mode: 'native',
+        };
+        return inputs[name] || '';
+      },
+      envSource: {},
+    });
+  }, /GitHub OIDC is unavailable/);
+});
+
+test('exchangeOidcForToken includes exchange failure detail', async () => {
+  let callCount = 0;
+
+  await assert.rejects(async () => {
+    await exchangeOidcForToken({
+      apiUrl: 'https://ir.example',
+      exchangeUrl: 'https://ir.example/oidc/exchange',
+      audience: 'invisirisk-oidc-validator',
+      projectId: 'project-123',
+      workflowPath: '',
+      envSource: {
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
+      },
+      fetchImpl: async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ value: 'github-oidc-token' }),
+          };
+        }
+        return {
+          ok: false,
+          status: 403,
+          json: async () => ({ detail: 'repository is not mapped to project' }),
+        };
+      },
+    });
+  }, /OIDC token exchange failed with status 403: repository is not mapped to project/);
+});
+
+test('exchangeOidcForToken rejects non-JSON exchange response', async () => {
+  let callCount = 0;
+
+  await assert.rejects(async () => {
+    await exchangeOidcForToken({
+      apiUrl: 'https://ir.example',
+      exchangeUrl: 'https://ir.example/oidc/exchange',
+      audience: 'invisirisk-oidc-validator',
+      projectId: 'project-123',
+      workflowPath: '',
+      envSource: {
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
+      },
+      fetchImpl: async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ value: 'github-oidc-token' }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new Error('invalid json');
+          },
+        };
+      },
+    });
+  }, /OIDC token exchange returned a non-JSON response/);
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -119,8 +119,6 @@ test('run exchanges GitHub OIDC for token when app_token is missing', async () =
   const inputs = {
     api_url: 'https://ir.example',
     app_token: '',
-    project_id: 'project-123',
-    workflow_path: '.github/workflows/build.yml',
     oidc_exchange_url: 'https://auth.example/oidc/exchange',
     oidc_audience: 'invisirisk-oidc-validator',
     debug: 'false',
@@ -172,11 +170,7 @@ test('run exchanges GitHub OIDC for token when app_token is missing', async () =
   assert.equal(calls[0].options.headers.Authorization, 'Bearer github-request-token');
   assert.equal(calls[1].url, 'https://auth.example/oidc/exchange');
   assert.deepEqual(JSON.parse(calls[1].options.body), {
-    api_url: 'https://ir.example',
-    project_id: 'project-123',
-    workflow_path: '.github/workflows/build.yml',
     oidc_token: 'github-oidc-token',
-    audience: 'invisirisk-oidc-validator',
   });
   assert.equal(execCall[2].env.IR_TOKEN, 'exchanged-runtime-token');
   assert.match(fs.readFileSync(githubEnvFile, 'utf8'), /IR_TOKEN=exchanged-runtime-token/);
@@ -186,7 +180,6 @@ test('run uses GITHUB_OIDC_AUDIENCE when oidc_audience input is missing', async 
   const inputs = {
     api_url: 'https://ir.example',
     app_token: '',
-    project_id: 'project-123',
     debug: 'false',
     mode: 'native',
     github_token: '',
@@ -241,27 +234,6 @@ test('run throws helpful error when api_url is missing', async () => {
   }, /Missing required input: api_url/);
 });
 
-test('run throws helpful error when token and project_id are missing', async () => {
-  await assert.rejects(async () => {
-    await run({
-      inputReader: (name) => {
-        const inputs = {
-          api_url: 'https://ir.example',
-          app_token: '',
-          debug: 'true',
-          mode: 'native',
-          pse_image_tag: 'latest',
-          collect_dependencies: 'true',
-          workdir: '/workspace',
-          github_token: '',
-        };
-        return inputs[name] || '';
-      },
-      envSource: {},
-    });
-  }, /Missing required input: project_id/);
-});
-
 test('run throws helpful error when GitHub OIDC environment is unavailable', async () => {
   await assert.rejects(async () => {
     await run({
@@ -269,7 +241,6 @@ test('run throws helpful error when GitHub OIDC environment is unavailable', asy
         const inputs = {
           api_url: 'https://ir.example',
           app_token: '',
-          project_id: 'project-123',
           debug: 'false',
           mode: 'native',
         };
@@ -285,11 +256,8 @@ test('exchangeOidcForToken includes exchange failure detail', async () => {
 
   await assert.rejects(async () => {
     await exchangeOidcForToken({
-      apiUrl: 'https://ir.example',
       exchangeUrl: 'https://ir.example/oidc/exchange',
       audience: 'invisirisk-oidc-validator',
-      projectId: 'project-123',
-      workflowPath: '',
       envSource: {
         ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
@@ -318,11 +286,8 @@ test('exchangeOidcForToken rejects non-JSON exchange response', async () => {
 
   await assert.rejects(async () => {
     await exchangeOidcForToken({
-      apiUrl: 'https://ir.example',
       exchangeUrl: 'https://ir.example/oidc/exchange',
       audience: 'invisirisk-oidc-validator',
-      projectId: 'project-123',
-      workflowPath: '',
       envSource: {
         ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,6 +7,9 @@ const {
   buildOidcExchangeUrl,
   exchangeOidcForToken,
   extractTokenFromExchangeResponse,
+  requestGithubWorkflowContext,
+  requestGithubOidcToken,
+  reportFailure,
   run,
   runBootstrap,
 } = require('./index');
@@ -16,6 +19,73 @@ test('buildOidcExchangeUrl defaults to /oidc/exchange', () => {
     buildOidcExchangeUrl('https://ir.example'),
     'https://ir.example/oidc/exchange',
   );
+});
+
+test('requestGithubWorkflowContext resolves numeric workflow ID and branch', async () => {
+  const context = await requestGithubWorkflowContext({
+    githubToken: 'github-api-token',
+    envSource: {
+      GITHUB_API_URL: 'https://github.example/api/v3',
+      GITHUB_REPOSITORY: 'invisirisk/pse-action',
+      GITHUB_RUN_ID: '987654',
+      GITHUB_REF_NAME: 'fallback-branch',
+    },
+    fetchImpl: async (url, options) => {
+      assert.equal(url, 'https://github.example/api/v3/repos/invisirisk/pse-action/actions/runs/987654');
+      assert.equal(options.headers.Authorization, 'Bearer github-api-token');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ workflow_id: 12345, head_branch: 'feature/oidc-context' }),
+      };
+    },
+  });
+
+  assert.deepEqual(context, {
+    branch: 'feature/oidc-context',
+    workflowId: 12345,
+  });
+});
+
+test('requestGithubWorkflowContext rejects runs without head_branch', async () => {
+  await assert.rejects(async () => {
+    await requestGithubWorkflowContext({
+      githubToken: 'github-api-token',
+      envSource: {
+        GITHUB_REPOSITORY: 'invisirisk/pse-action',
+        GITHUB_RUN_ID: '987654',
+        GITHUB_REF_NAME: 'tag-that-must-not-be-used-as-a-branch',
+      },
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ workflow_id: 12345, head_branch: null }),
+      }),
+    });
+  }, /could not identify a branch.*tag or without a branch are not supported/);
+});
+
+test('requestGithubOidcToken explains how to enable secure sign-in', async () => {
+  await assert.rejects(async () => {
+    await requestGithubOidcToken('invisirisk-oidc-validator', {});
+  }, /requires permission to verify this workflow.*id-token: write/);
+});
+
+test('reportFailure creates a clear GitHub error annotation without a public error code', async () => {
+  let oidcFailure;
+  try {
+    await requestGithubOidcToken('invisirisk-oidc-validator', {});
+  } catch (error) {
+    oidcFailure = error;
+  }
+
+  const messages = [];
+  reportFailure(oidcFailure, (message) => messages.push(message));
+
+  assert.equal(messages.length, 1);
+  assert.match(messages[0], /^::error title=PSE requires secure sign-in access::/);
+  assert.match(messages[0], /Add "id-token: write" to the workflow permissions/);
+  assert.doesNotMatch(messages[0], /PSE-OIDC|Reference:/);
 });
 
 test('runBootstrap sets mode to native for docker-intercept or missing MODE', () => {
@@ -127,7 +197,7 @@ test('run exchanges GitHub OIDC for token when app_token is missing', async () =
     app_token: '',
     debug: 'false',
     mode: 'native',
-    github_token: '',
+    github_token: 'github-api-token',
   };
   const githubEnvFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'pse-action-')), 'env');
   const originalGithubEnv = process.env.GITHUB_ENV;
@@ -144,9 +214,19 @@ test('run exchanges GitHub OIDC for token when app_token is missing', async () =
       envSource: {
         ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
+        GITHUB_REPOSITORY: 'invisirisk/pse-action',
+        GITHUB_RUN_ID: '987654',
+        GITHUB_REF_NAME: 'fallback-branch',
       },
       fetchImpl: async (url, options) => {
         calls.push({ url, options });
+        if (url === 'https://api.github.com/repos/invisirisk/pse-action/actions/runs/987654') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ workflow_id: 12345, head_branch: 'feature/oidc-context' }),
+          };
+        }
         if (url.startsWith('https://token.actions.githubusercontent.com/id-token')) {
           return {
             ok: true,
@@ -169,12 +249,15 @@ test('run exchanges GitHub OIDC for token when app_token is missing', async () =
     }
   }
 
-  assert.equal(calls.length, 2);
-  assert.match(calls[0].url, /audience=invisirisk-oidc-validator/);
-  assert.equal(calls[0].options.headers.Authorization, 'Bearer github-request-token');
-  assert.equal(calls[1].url, 'https://ir.example/oidc/exchange');
-  assert.deepEqual(JSON.parse(calls[1].options.body), {
+  assert.equal(calls.length, 3);
+  assert.equal(calls[0].options.headers.Authorization, 'Bearer github-api-token');
+  assert.match(calls[1].url, /audience=invisirisk-oidc-validator/);
+  assert.equal(calls[1].options.headers.Authorization, 'Bearer github-request-token');
+  assert.equal(calls[2].url, 'https://ir.example/oidc/exchange');
+  assert.deepEqual(JSON.parse(calls[2].options.body), {
     oidc_token: 'github-oidc-token',
+    branch: 'feature/oidc-context',
+    workflow_id: 12345,
   });
   assert.equal(execCall[2].env.IR_TOKEN, 'exchanged-runtime-token');
   assert.match(fs.readFileSync(githubEnvFile, 'utf8'), /IR_TOKEN=exchanged-runtime-token/);
@@ -219,7 +302,7 @@ test('run throws helpful error when api_url is missing', async () => {
   }, /Missing required input: api_url/);
 });
 
-test('run throws helpful error when GitHub OIDC environment is unavailable', async () => {
+test('run throws helpful error when GitHub workflow context is unavailable', async () => {
   await assert.rejects(async () => {
     await run({
       inputReader: (name) => {
@@ -233,16 +316,18 @@ test('run throws helpful error when GitHub OIDC environment is unavailable', asy
       },
       envSource: {},
     });
-  }, /GitHub OIDC is unavailable/);
+  }, /requires permission to read this workflow run.*actions: read/);
 });
 
-test('exchangeOidcForToken includes exchange failure detail', async () => {
+test('exchangeOidcForToken explains an inactive project connection without exposing backend detail', async () => {
   let callCount = 0;
 
   await assert.rejects(async () => {
     await exchangeOidcForToken({
       exchangeUrl: 'https://ir.example/oidc/exchange',
       audience: 'invisirisk-oidc-validator',
+      branch: 'develop',
+      workflowId: 12345,
       envSource: {
         ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
@@ -263,16 +348,23 @@ test('exchangeOidcForToken includes exchange failure detail', async () => {
         };
       },
     });
-  }, /OIDC token exchange failed with status 403: repository is not mapped to project/);
+  }, (error) => {
+    assert.match(error.message, /not connected to an active PSE project/);
+    assert.doesNotMatch(error.message, /repository is not mapped to project/);
+    assert.doesNotMatch(error.message, /403/);
+    return true;
+  });
 });
 
-test('exchangeOidcForToken rejects Lambda proxy error response', async () => {
+test('exchangeOidcForToken normalizes a Lambda proxy error for the user', async () => {
   let callCount = 0;
 
   await assert.rejects(async () => {
     await exchangeOidcForToken({
       exchangeUrl: 'https://ir.example/oidc/exchange',
       audience: 'invisirisk-oidc-validator',
+      branch: 'develop',
+      workflowId: 12345,
       envSource: {
         ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
@@ -299,16 +391,23 @@ test('exchangeOidcForToken rejects Lambda proxy error response', async () => {
         };
       },
     });
-  }, /OIDC token exchange failed with status 403: No active repository mapping found for repository/);
+  }, (error) => {
+    assert.match(error.message, /not connected to an active PSE project/);
+    assert.doesNotMatch(error.message, /No active repository mapping/);
+    assert.doesNotMatch(error.message, /403/);
+    return true;
+  });
 });
 
-test('exchangeOidcForToken rejects non-JSON exchange response', async () => {
+test('exchangeOidcForToken hides malformed response details from the user', async () => {
   let callCount = 0;
 
   await assert.rejects(async () => {
     await exchangeOidcForToken({
       exchangeUrl: 'https://ir.example/oidc/exchange',
       audience: 'invisirisk-oidc-validator',
+      branch: 'develop',
+      workflowId: 12345,
       envSource: {
         ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/id-token',
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
@@ -331,5 +430,5 @@ test('exchangeOidcForToken rejects non-JSON exchange response', async () => {
         };
       },
     });
-  }, /OIDC token exchange returned a non-JSON response/);
+  }, /unexpected secure sign-in response/);
 });

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,0 +1,187 @@
+const CONFIGURATION_REQUIRED = {
+  title: 'BAF configuration required',
+  message: 'Secure sign-in is not configured correctly. Contact your BAF administrator.',
+};
+
+const WORKFLOW_ACCESS_REQUIRED = {
+  title: 'BAF requires workflow access',
+  message: 'BAF requires permission to read this workflow run. Add "actions: read" to the workflow permissions, then rerun the workflow.',
+};
+
+const WORKFLOW_CONTEXT_MISSING = {
+  title: 'BAF could not verify this workflow',
+  message: 'BAF could not identify the current GitHub Actions run. Ensure BAF is running inside a GitHub Actions workflow.',
+};
+
+const WORKFLOW_UNAVAILABLE = {
+  title: 'BAF workflow verification unavailable',
+  message: 'This runner cannot provide the current workflow details. Use a supported GitHub Actions runner or contact your BAF administrator.',
+};
+
+const WORKFLOW_CONNECTION_UNAVAILABLE = {
+  title: 'GitHub connection unavailable',
+  message: 'BAF could not reach GitHub to verify this workflow. Verify the runner can connect to GitHub, then rerun the workflow.',
+};
+
+const WORKFLOW_RESPONSE_INVALID = {
+  title: 'BAF could not verify this workflow',
+  message: 'GitHub returned an unexpected response while BAF was verifying this workflow. Retry the workflow; if the issue persists, contact your BAF administrator.',
+};
+
+const WORKFLOW_ID_MISSING = {
+  title: 'BAF could not verify this workflow',
+  message: 'BAF could not identify the current workflow. Retry the workflow; if the issue persists, contact your BAF administrator.',
+};
+
+const BRANCH_REQUIRED = {
+  title: 'BAF requires a branch-based run',
+  message: 'BAF could not identify a branch for this run. Workflows started from a tag or without a branch are not supported.',
+};
+
+const SECURE_SIGN_IN_ACCESS_REQUIRED = {
+  title: 'BAF requires secure sign-in access',
+  message: 'BAF requires permission to verify this workflow with GitHub. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
+};
+
+const SECURE_SIGN_IN_UNAVAILABLE = {
+  title: 'BAF secure sign-in unavailable',
+  message: 'This runner does not support BAF secure sign-in. Use a supported GitHub Actions runner or contact your BAF administrator.',
+};
+
+const GITHUB_CONNECTION_UNAVAILABLE = {
+  title: 'GitHub connection unavailable',
+  message: 'BAF could not reach GitHub for secure sign-in. Verify the runner can connect to GitHub, then rerun the workflow.',
+};
+
+const GITHUB_ACCESS_DENIED = {
+  title: 'BAF requires secure sign-in access',
+  message: 'GitHub did not allow BAF to verify this workflow. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
+};
+
+const GITHUB_RESPONSE_INVALID = {
+  title: 'BAF secure sign-in failed',
+  message: 'GitHub returned an unexpected secure sign-in response. Retry the workflow; if the issue persists, contact your BAF administrator.',
+};
+
+const GITHUB_TOKEN_MISSING = {
+  title: 'BAF secure sign-in failed',
+  message: 'GitHub did not complete secure sign-in for this workflow. Retry the workflow; if the issue persists, contact your BAF administrator.',
+};
+
+const EXCHANGE_CONNECTION_UNAVAILABLE = {
+  title: 'BAF connection unavailable',
+  message: 'The runner could not reach BAF for secure sign-in. Verify the runner network connection, then rerun the workflow.',
+};
+
+const EXCHANGE_RESPONSE_INVALID = {
+  title: 'BAF secure sign-in failed',
+  message: 'BAF received an unexpected secure sign-in response. Retry the workflow; if the issue persists, contact your BAF administrator.',
+};
+
+const EXCHANGE_TOKEN_MISSING = {
+  title: 'BAF secure sign-in failed',
+  message: 'BAF secure sign-in did not complete. Retry the workflow; if the issue persists, contact your BAF administrator.',
+};
+
+const OIDC_MESSAGES = {
+  configurationRequired: CONFIGURATION_REQUIRED,
+  github: {
+    accessRequired: SECURE_SIGN_IN_ACCESS_REQUIRED,
+    runnerUnavailable: SECURE_SIGN_IN_UNAVAILABLE,
+    connectionUnavailable: GITHUB_CONNECTION_UNAVAILABLE,
+    accessDenied: GITHUB_ACCESS_DENIED,
+    invalidResponse: GITHUB_RESPONSE_INVALID,
+    tokenMissing: GITHUB_TOKEN_MISSING,
+  },
+  workflow: {
+    accessRequired: WORKFLOW_ACCESS_REQUIRED,
+    contextMissing: WORKFLOW_CONTEXT_MISSING,
+    runnerUnavailable: WORKFLOW_UNAVAILABLE,
+    connectionUnavailable: WORKFLOW_CONNECTION_UNAVAILABLE,
+    invalidResponse: WORKFLOW_RESPONSE_INVALID,
+    idMissing: WORKFLOW_ID_MISSING,
+    branchRequired: BRANCH_REQUIRED,
+  },
+  exchange: {
+    connectionUnavailable: EXCHANGE_CONNECTION_UNAVAILABLE,
+    invalidResponse: EXCHANGE_RESPONSE_INVALID,
+    tokenMissing: EXCHANGE_TOKEN_MISSING,
+  },
+};
+
+const REQUEST_ERROR_MESSAGES = {
+  github: {
+    access: WORKFLOW_ACCESS_REQUIRED,
+    notFound: {
+      title: 'BAF could not verify this workflow',
+      message: 'GitHub could not locate the current workflow run. Rerun the workflow; if the issue persists, contact your BAF administrator.',
+    },
+    unavailable: {
+      title: 'GitHub is temporarily unavailable',
+      message: 'BAF could not verify this workflow with GitHub. Retry the workflow; if the issue persists, contact your BAF administrator.',
+    },
+    default: {
+      title: 'BAF could not verify this workflow',
+      message: 'BAF could not verify the current workflow run. Retry the workflow; if the issue persists, contact your BAF administrator.',
+    },
+  },
+  oidc: {
+    unauthorized: {
+      title: 'BAF requires secure sign-in access',
+      message: 'GitHub could not verify this workflow for BAF. Add "id-token: write" to the workflow permissions, then rerun the workflow.',
+    },
+    forbidden: {
+      title: 'BAF project connection required',
+      message: 'This repository, branch, or workflow is not connected to an active BAF project. Verify the project mapping and GitHub App installation in BAF, then rerun the workflow.',
+    },
+    notFound: {
+      title: 'BAF project connection required',
+      message: 'No BAF project connection was found for this workflow. Connect the repository, branch, and workflow to a BAF project, then rerun the workflow.',
+    },
+    rateLimited: {
+      title: 'BAF sign-in temporarily unavailable',
+      message: 'BAF cannot accept another secure sign-in request at this time. Retry the workflow shortly.',
+    },
+    unavailable: {
+      title: 'BAF sign-in temporarily unavailable',
+      message: 'BAF secure sign-in is temporarily unavailable. Retry the workflow; if the issue persists, contact your BAF administrator.',
+    },
+    default: {
+      title: 'BAF secure sign-in failed',
+      message: 'BAF could not complete secure sign-in. Retry the workflow; if the issue persists, contact your BAF administrator.',
+    },
+  },
+};
+
+const REQUEST_ERROR_TYPES = {
+  github: {
+    401: 'access',
+    403: 'access',
+    404: 'notFound',
+    429: 'unavailable',
+    serverError: 'unavailable',
+  },
+  oidc: {
+    401: 'unauthorized',
+    403: 'forbidden',
+    404: 'notFound',
+    429: 'rateLimited',
+    serverError: 'unavailable',
+  },
+};
+
+function getRequestErrorMessage(origin, status) {
+  const messages = REQUEST_ERROR_MESSAGES[origin];
+  const types = REQUEST_ERROR_TYPES[origin];
+  if (!messages || !types) {
+    throw new Error(`Unsupported request error origin: ${origin}`);
+  }
+
+  const errorType = types[status] || (status >= 500 ? types.serverError : 'default');
+  return messages[errorType];
+}
+
+module.exports = {
+  getRequestErrorMessage,
+  OIDC_MESSAGES,
+};

--- a/src/post.js
+++ b/src/post.js
@@ -4,7 +4,7 @@ const { buildEnv, getInput, getState, handleDeprecatedInputs, pick } = require('
 function run(spawn = spawnSync, stdout = process.stdout, stderr = process.stderr) {
   const env = buildEnv({
     IR_URL: pick(getInput('api_url'), process.env.PSE_API_URL),
-    IR_TOKEN: pick(getInput('app_token'), process.env.PSE_APP_TOKEN),
+    IR_TOKEN: pick(getInput('app_token'), process.env.IR_TOKEN, process.env.PSE_APP_TOKEN, process.env.APP_TOKEN),
     SEND_JOB_STATUS: getInput('collect_job_status') === 'false' ? 'false' : 'true',
   });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,14 +38,6 @@ function exportVariable(name, value) {
   process.env[name] = value;
   const envFile = process.env.GITHUB_ENV;
   if (envFile) {
-    if (String(value).includes('\n')) {
-      let delimiter = `PSE_${name}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-      while (String(value).includes(delimiter)) {
-        delimiter = `PSE_${name}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-      }
-      fs.appendFileSync(envFile, `${name}<<${delimiter}${os.EOL}${value}${os.EOL}${delimiter}${os.EOL}`, 'utf8');
-      return;
-    }
     fs.appendFileSync(envFile, `${name}=${value}${os.EOL}`, 'utf8');
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,6 +34,28 @@ function saveState(name, value) {
   }
 }
 
+function exportVariable(name, value) {
+  process.env[name] = value;
+  const envFile = process.env.GITHUB_ENV;
+  if (envFile) {
+    if (String(value).includes('\n')) {
+      let delimiter = `PSE_${name}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      while (String(value).includes(delimiter)) {
+        delimiter = `PSE_${name}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      }
+      fs.appendFileSync(envFile, `${name}<<${delimiter}${os.EOL}${value}${os.EOL}${delimiter}${os.EOL}`, 'utf8');
+      return;
+    }
+    fs.appendFileSync(envFile, `${name}=${value}${os.EOL}`, 'utf8');
+  }
+}
+
+function maskSecret(value) {
+  if (value) {
+    console.log(`::add-mask::${value}`);
+  }
+}
+
 function buildEnv(overrides = {}) {
   return {
     ...process.env,
@@ -78,11 +100,13 @@ function handleDeprecatedInputs(isPost = false) {
 
 module.exports = {
   buildEnv,
+  exportVariable,
   getState,
   getInput,
   handleDeprecatedCleanupInput,
   handleDeprecatedInputs,
   handleDeprecatedSendJobStatusInput,
+  maskSecret,
   pick,
   saveState,
 };


### PR DESCRIPTION
## Summary

  Adds branch-aware GitHub OIDC authentication to PSE while preserving existing `app_token` authentication.

  When `app_token` is omitted, the action now:

  1. Resolves the current branch and numeric workflow ID from the GitHub Actions API.
  2. Requests a GitHub OIDC token.
  3. Exchanges it with PSE for a runtime API token.
  4. Masks and exports the token for use during setup and post-action cleanup.

  ## Changes

  - Make `app_token` optional and use OIDC as the fallback authentication method.
  - Resolve the workflow ID and branch from the current GitHub Actions run.
  - Exchange GitHub OIDC credentials through `/oidc/exchange`.
  - Support direct and Lambda proxy-style exchange responses.
  - Reuse the exchanged token during the post-action step.
  - Add actionable GitHub error annotations for:
    - Missing workflow or OIDC permissions
    - Missing repository, branch, or workflow mappings
    - Unsupported tag-based runs
    - GitHub or PSE availability issues
    - Invalid authentication responses
  - Mask runtime credentials and avoid exposing backend response details.
  - Retain compatibility with explicitly provided `app_token` and token environment variables.
  - Add test coverage for OIDC authentication, workflow context resolution, response handling, and failure scenarios.