### PR TITLE
RELEASE 07/29:  Enhance job handling with customizable labels and matrix support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,12 @@ inputs:
     description: 'GitHub token used to resolve the current numeric workflow ID. Auto-populated; OIDC mode requires actions: read permission.'
     required: false
     default: ${{ github.token }}
-  job_name:
-    description: 'GitHub Actions job label to attach to the scan. Defaults to the stable job id.'
+  job_identifier:
+    description: 'Stable job identifier used to compare the same job across runs. Derived automatically when omitted.'
     required: false
-    default: "${{ github.job }}"
+  job_label:
+    description: 'Readable job label shown for the scan. Derived automatically when omitted.'
+    required: false
   matrix_obj:
     description: 'GitHub Actions matrix metadata used to distinguish matrix jobs.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'GitHub token used to resolve the current numeric workflow ID. Auto-populated; OIDC mode requires actions: read permission.'
     required: false
     default: ${{ github.token }}
+  job_name:
+    description: 'GitHub Actions job label to attach to the scan. Defaults to the job id and appends matrix values when present.'
+    required: false
+    default: "${{ github.job }}${{ toJson(matrix) != '{}' && format(' {0}', toJson(matrix)) || '' }}"
   debug:
     description: 'Enable debug mode for verbose logging'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
   job_name:
     description: 'GitHub Actions job label to attach to the scan. Defaults to the job id and appends matrix values when present.'
     required: false
-    default: "${{ github.job }}${{ toJson(matrix) != '{}' && format(' {0}', toJson(matrix)) || '' }}"
+    default: "${{ github.job }}${{ toJson(matrix) != 'null' && toJson(matrix) != '{}' && format(' {0}', toJson(matrix)) || '' }}"
   debug:
     description: 'Enable debug mode for verbose logging'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,13 @@ inputs:
     required: false
     default: ${{ github.token }}
   job_name:
-    description: 'GitHub Actions job label to attach to the scan. Defaults to the job id and appends matrix values when present.'
+    description: 'GitHub Actions job label to attach to the scan. Defaults to the stable job id.'
     required: false
-    default: "${{ github.job }}${{ toJson(matrix) != 'null' && toJson(matrix) != '{}' && format(' {0}', toJson(matrix)) || '' }}"
+    default: "${{ github.job }}"
+  matrix_obj:
+    description: 'GitHub Actions matrix metadata used to distinguish matrix jobs.'
+    required: false
+    default: "${{ toJson(matrix) }}"
   debug:
     description: 'Enable debug mode for verbose logging'
     required: false

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const { execFileSync } = require('child_process');
+const { createHash } = require('crypto');
 const { getRequestErrorMessage, OIDC_MESSAGES } = require('./messages');
 const { buildEnv, exportVariable, getInput, handleDeprecatedInputs, maskSecret, pick, saveState } = require('./utils');
 
@@ -285,6 +286,31 @@ function isUnevaluatedExpression(value) {
   return typeof value === 'string' && value.includes('${{');
 }
 
+function matrixIdentifier(value) {
+  const input = pick(value);
+  if (!input || input === 'null' || input === '{}' || isUnevaluatedExpression(input)) {
+    return '';
+  }
+
+  let matrix;
+  try {
+    matrix = JSON.parse(input);
+  } catch {
+    return '';
+  }
+  if (!matrix || typeof matrix !== 'object' || Array.isArray(matrix)) {
+    return '';
+  }
+
+  const preferred = matrix.label ?? matrix.name;
+  if (preferred !== undefined && preferred !== null && String(preferred).trim()) {
+    return String(preferred).replace(/\s+/g, ' ').trim();
+  }
+
+  const hash = createHash('sha256').update(JSON.stringify(matrix)).digest('hex').slice(0, 8);
+  return `matrix-${hash}`;
+}
+
 function runBootstrap(env, execFile = execFileSync) {
   const bootstrapUrl = new URL('/ingestionapi/v1/pse/bootstrap', env.IR_URL);
   bootstrapUrl.search = new URLSearchParams({
@@ -354,9 +380,11 @@ function buildRuntimeEnv(inputReader = getInput, envSource = process.env) {
   }
 
   const inputJobName = pick(inputReader('job_name'));
-  const jobName = inputJobName && !isUnevaluatedExpression(inputJobName)
+  const baseJobName = inputJobName && !isUnevaluatedExpression(inputJobName)
     ? inputJobName
     : pick(envSource.JOB_NAME, envSource.GITHUB_JOB);
+  const matrixName = matrixIdentifier(inputReader('matrix_obj'));
+  const jobName = [baseJobName, matrixName].filter(Boolean).join(' ');
   if (jobName) {
     env.JOB_NAME = jobName;
   }
@@ -424,6 +452,7 @@ module.exports = {
   buildOidcExchangeUrl,
   exchangeOidcForToken,
   extractTokenFromExchangeResponse,
+  matrixIdentifier,
   requestGithubWorkflowContext,
   requestGithubOidcToken,
   reportFailure,

--- a/src/index.js
+++ b/src/index.js
@@ -281,6 +281,10 @@ async function exchangeOidcForToken({
   return token;
 }
 
+function isUnevaluatedExpression(value) {
+  return typeof value === 'string' && value.includes('${{');
+}
+
 function runBootstrap(env, execFile = execFileSync) {
   const bootstrapUrl = new URL('/ingestionapi/v1/pse/bootstrap', env.IR_URL);
   bootstrapUrl.search = new URLSearchParams({
@@ -347,6 +351,14 @@ function buildRuntimeEnv(inputReader = getInput, envSource = process.env) {
   const githubToken = pick(inputReader('github_token'), envSource.GITHUB_TOKEN);
   if (githubToken) {
     env.GITHUB_TOKEN = githubToken;
+  }
+
+  const inputJobName = pick(inputReader('job_name'));
+  const jobName = inputJobName && !isUnevaluatedExpression(inputJobName)
+    ? inputJobName
+    : pick(envSource.JOB_NAME, envSource.GITHUB_JOB);
+  if (jobName) {
+    env.JOB_NAME = jobName;
   }
 
   return env;

--- a/src/index.js
+++ b/src/index.js
@@ -286,29 +286,29 @@ function isUnevaluatedExpression(value) {
   return typeof value === 'string' && value.includes('${{');
 }
 
-function matrixIdentifier(value) {
+function matrixIdentity(value) {
   const input = pick(value);
   if (!input || input === 'null' || input === '{}' || isUnevaluatedExpression(input)) {
-    return '';
+    return { scanKey: '', scanLabel: '' };
   }
 
   let matrix;
   try {
     matrix = JSON.parse(input);
   } catch {
-    return '';
+    return { scanKey: '', scanLabel: '' };
   }
   if (!matrix || typeof matrix !== 'object' || Array.isArray(matrix)) {
-    return '';
-  }
-
-  const preferred = matrix.label ?? matrix.name;
-  if (preferred !== undefined && preferred !== null && String(preferred).trim()) {
-    return String(preferred).replace(/\s+/g, ' ').trim();
+    return { scanKey: '', scanLabel: '' };
   }
 
   const hash = createHash('sha256').update(JSON.stringify(matrix)).digest('hex').slice(0, 8);
-  return `matrix-${hash}`;
+  const scanKey = 'matrix-' + hash;
+  const preferred = matrix.label ?? matrix.name;
+  const scanLabel = preferred !== undefined && preferred !== null && String(preferred).trim()
+    ? String(preferred).replace(/\s+/g, ' ').trim()
+    : scanKey;
+  return { scanKey, scanLabel };
 }
 
 function runBootstrap(env, execFile = execFileSync) {
@@ -383,10 +383,16 @@ function buildRuntimeEnv(inputReader = getInput, envSource = process.env) {
   const baseJobName = inputJobName && !isUnevaluatedExpression(inputJobName)
     ? inputJobName
     : pick(envSource.JOB_NAME, envSource.GITHUB_JOB);
-  const matrixName = matrixIdentifier(inputReader('matrix_obj'));
-  const jobName = [baseJobName, matrixName].filter(Boolean).join(' ');
+  const matrix = matrixIdentity(inputReader('matrix_obj'));
+  const jobName = [baseJobName, matrix.scanLabel].filter(Boolean).join(' ');
+  const jobExternalId = [pick(envSource.JOB_EXTERNAL_ID, envSource.GITHUB_JOB, baseJobName), matrix.scanKey]
+    .filter(Boolean)
+    .join(' ');
   if (jobName) {
     env.JOB_NAME = jobName;
+  }
+  if (jobExternalId) {
+    env.JOB_EXTERNAL_ID = jobExternalId;
   }
 
   return env;
@@ -452,7 +458,7 @@ module.exports = {
   buildOidcExchangeUrl,
   exchangeOidcForToken,
   extractTokenFromExchangeResponse,
-  matrixIdentifier,
+  matrixIdentity,
   requestGithubWorkflowContext,
   requestGithubOidcToken,
   reportFailure,

--- a/src/index.js
+++ b/src/index.js
@@ -313,11 +313,18 @@ function matrixIdentity(value) {
 
 function runBootstrap(env, execFile = execFileSync) {
   const bootstrapUrl = new URL('/ingestionapi/v1/pse/bootstrap', env.IR_URL);
-  bootstrapUrl.search = new URLSearchParams({
+  const bootstrapParams = new URLSearchParams({
     //? for backwards compatibility, if MODE is `docker-intercept`, we want to use native mode for the bootstrap script
     mode: !env.MODE || env.MODE === "docker-intercept" ? "native" : env.MODE,
     runner: env.RUNNER || 'github',
-  }).toString();
+  });
+  if (env.PSE_JOB_IDENTIFIER) {
+    bootstrapParams.set('job_identifier', env.PSE_JOB_IDENTIFIER);
+  }
+  if (env.PSE_JOB_LABEL) {
+    bootstrapParams.set('job_label', env.PSE_JOB_LABEL);
+  }
+  bootstrapUrl.search = bootstrapParams.toString();
 
   env.BOOTSTRAP_URL = bootstrapUrl.toString();
 
@@ -379,20 +386,26 @@ function buildRuntimeEnv(inputReader = getInput, envSource = process.env) {
     env.GITHUB_TOKEN = githubToken;
   }
 
-  const inputJobName = pick(inputReader('job_name'));
-  const baseJobName = inputJobName && !isUnevaluatedExpression(inputJobName)
-    ? inputJobName
-    : pick(envSource.JOB_NAME, envSource.GITHUB_JOB);
+  const baseJobLabel = pick(envSource.GITHUB_JOB);
   const matrix = matrixIdentity(inputReader('matrix_obj'));
-  const jobName = [baseJobName, matrix.scanLabel].filter(Boolean).join(' ');
-  const jobExternalId = [pick(envSource.JOB_EXTERNAL_ID, envSource.GITHUB_JOB, baseJobName), matrix.scanKey]
-    .filter(Boolean)
-    .join(' ');
-  if (jobName) {
-    env.JOB_NAME = jobName;
+  const derivedJobLabel = [baseJobLabel, matrix.scanLabel].filter(Boolean).join(' ');
+  const inputJobLabel = pick(inputReader('job_label'));
+  const jobLabel = inputJobLabel && !isUnevaluatedExpression(inputJobLabel)
+    ? inputJobLabel
+    : derivedJobLabel;
+
+  const baseJobIdentifier = baseJobLabel;
+  const derivedJobIdentifier = [baseJobIdentifier, matrix.scanKey].filter(Boolean).join(' ');
+  const inputJobIdentifier = pick(inputReader('job_identifier'));
+  const jobIdentifier = inputJobIdentifier && !isUnevaluatedExpression(inputJobIdentifier)
+    ? inputJobIdentifier
+    : derivedJobIdentifier;
+
+  if (jobLabel) {
+    env.PSE_JOB_LABEL = jobLabel;
   }
-  if (jobExternalId) {
-    env.JOB_EXTERNAL_ID = jobExternalId;
+  if (jobIdentifier) {
+    env.PSE_JOB_IDENTIFIER = jobIdentifier;
   }
 
   return env;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -504,3 +504,43 @@ test('exchangeOidcForToken hides malformed response details from the user', asyn
     });
   }, /unexpected secure sign-in response/);
 });
+
+test('run passes job_name through to bootstrap environment', () => {
+  const inputs = {
+    api_url: 'https://ir.example',
+    app_token: 'token',
+    github_token: '',
+    job_name: 'build {"os":"ubuntu-latest","node":"20"}',
+  };
+  let execCall;
+
+  run({
+    execFile: (...args) => {
+      execCall = args;
+    },
+    inputReader: (name) => inputs[name] || '',
+    envSource: { GITHUB_TOKEN: 'default-gh-token', GITHUB_JOB: 'build' },
+  });
+
+  assert.equal(execCall[2].env.JOB_NAME, 'build {"os":"ubuntu-latest","node":"20"}');
+});
+
+test('run falls back to GITHUB_JOB when job_name expression is not evaluated', () => {
+  const inputs = {
+    api_url: 'https://ir.example',
+    app_token: 'token',
+    github_token: '',
+    job_name: '${{ github.job }}${{ toJson(matrix) }}',
+  };
+  let execCall;
+
+  run({
+    execFile: (...args) => {
+      execCall = args;
+    },
+    inputReader: (name) => inputs[name] || '',
+    envSource: { GITHUB_TOKEN: 'default-gh-token', GITHUB_JOB: 'build' },
+  });
+
+  assert.equal(execCall[2].env.JOB_NAME, 'build');
+});

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -506,12 +506,11 @@ test('exchangeOidcForToken hides malformed response details from the user', asyn
   }, /unexpected secure sign-in response/);
 });
 
-test('run passes job_name through to bootstrap environment', () => {
+test('run derives generic matrix job parameters for bootstrap', () => {
   const inputs = {
     api_url: 'https://ir.example',
     app_token: 'token',
     github_token: '',
-    job_name: 'build',
     matrix_obj: JSON.stringify({ name: 'ubuntu-2204', base_image: 'ubuntu:22.04' }, null, 2),
   };
   let execCall;
@@ -524,8 +523,37 @@ test('run passes job_name through to bootstrap environment', () => {
     envSource: { GITHUB_TOKEN: 'default-gh-token', GITHUB_JOB: 'build' },
   });
 
-  assert.equal(execCall[2].env.JOB_NAME, 'build ubuntu-2204');
-  assert.match(execCall[2].env.JOB_EXTERNAL_ID, /^build matrix-[0-9a-f]{8}$/);
+  assert.equal(execCall[2].env.PSE_JOB_LABEL, 'build ubuntu-2204');
+  assert.match(execCall[2].env.PSE_JOB_IDENTIFIER, /^build matrix-[0-9a-f]{8}$/);
+  const bootstrapUrl = new URL(execCall[2].env.BOOTSTRAP_URL);
+  assert.equal(bootstrapUrl.searchParams.get('job_label'), 'build ubuntu-2204');
+  assert.equal(bootstrapUrl.searchParams.get('job_identifier'), execCall[2].env.PSE_JOB_IDENTIFIER);
+});
+
+test('run forwards explicit generic job parameters without matrix decoration', () => {
+  const inputs = {
+    api_url: 'https://ir.example',
+    app_token: 'token',
+    github_token: '',
+    job_identifier: 'customer-build-linux',
+    job_label: 'Customer Build Linux',
+    matrix_obj: JSON.stringify({ name: 'ubuntu-2204' }),
+  };
+  let execCall;
+
+  run({
+    execFile: (...args) => {
+      execCall = args;
+    },
+    inputReader: (name) => inputs[name] || '',
+    envSource: { GITHUB_TOKEN: 'default-gh-token', GITHUB_JOB: 'build' },
+  });
+
+  assert.equal(execCall[2].env.PSE_JOB_IDENTIFIER, 'customer-build-linux');
+  assert.equal(execCall[2].env.PSE_JOB_LABEL, 'Customer Build Linux');
+  const bootstrapUrl = new URL(execCall[2].env.BOOTSTRAP_URL);
+  assert.equal(bootstrapUrl.searchParams.get('job_identifier'), 'customer-build-linux');
+  assert.equal(bootstrapUrl.searchParams.get('job_label'), 'Customer Build Linux');
 });
 
 test('matrixIdentity separates the stable scan key from the readable scan label', () => {
@@ -542,12 +570,11 @@ test('matrixIdentity separates the stable scan key from the readable scan label'
   assert.equal(fallback.scanKey, matrixIdentity(JSON.stringify({ os: 'ubuntu-latest', node: 20 })).scanKey);
 });
 
-test('run falls back to GITHUB_JOB when job_name expression is not evaluated', () => {
+test('run derives both job values from GITHUB_JOB without explicit inputs', () => {
   const inputs = {
     api_url: 'https://ir.example',
     app_token: 'token',
     github_token: '',
-    job_name: '${{ github.job }}${{ toJson(matrix) }}',
   };
   let execCall;
 
@@ -559,6 +586,6 @@ test('run falls back to GITHUB_JOB when job_name expression is not evaluated', (
     envSource: { GITHUB_TOKEN: 'default-gh-token', GITHUB_JOB: 'build' },
   });
 
-  assert.equal(execCall[2].env.JOB_NAME, 'build');
-  assert.equal(execCall[2].env.JOB_EXTERNAL_ID, 'build');
+  assert.equal(execCall[2].env.PSE_JOB_LABEL, 'build');
+  assert.equal(execCall[2].env.PSE_JOB_IDENTIFIER, 'build');
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,6 +7,7 @@ const {
   buildOidcExchangeUrl,
   exchangeOidcForToken,
   extractTokenFromExchangeResponse,
+  matrixIdentifier,
   requestGithubWorkflowContext,
   requestGithubOidcToken,
   reportFailure,
@@ -510,7 +511,8 @@ test('run passes job_name through to bootstrap environment', () => {
     api_url: 'https://ir.example',
     app_token: 'token',
     github_token: '',
-    job_name: 'build {"os":"ubuntu-latest","node":"20"}',
+    job_name: 'build',
+    matrix_obj: JSON.stringify({ name: 'ubuntu-2204', base_image: 'ubuntu:22.04' }, null, 2),
   };
   let execCall;
 
@@ -522,7 +524,16 @@ test('run passes job_name through to bootstrap environment', () => {
     envSource: { GITHUB_TOKEN: 'default-gh-token', GITHUB_JOB: 'build' },
   });
 
-  assert.equal(execCall[2].env.JOB_NAME, 'build {"os":"ubuntu-latest","node":"20"}');
+  assert.equal(execCall[2].env.JOB_NAME, 'build ubuntu-2204');
+});
+
+test('matrixIdentifier prefers label, then name, with a stable hash fallback', () => {
+  assert.equal(matrixIdentifier(JSON.stringify({ label: 'Linux AMD64', name: 'ubuntu-2204' })), 'Linux AMD64');
+  assert.equal(matrixIdentifier(JSON.stringify({ name: 'rockylinux-8' }, null, 2)), 'rockylinux-8');
+
+  const fallback = matrixIdentifier(JSON.stringify({ os: 'ubuntu-latest', node: 20 }));
+  assert.match(fallback, /^matrix-[0-9a-f]{8}$/);
+  assert.equal(fallback, matrixIdentifier(JSON.stringify({ os: 'ubuntu-latest', node: 20 })));
 });
 
 test('run falls back to GITHUB_JOB when job_name expression is not evaluated', () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,7 +7,7 @@ const {
   buildOidcExchangeUrl,
   exchangeOidcForToken,
   extractTokenFromExchangeResponse,
-  matrixIdentifier,
+  matrixIdentity,
   requestGithubWorkflowContext,
   requestGithubOidcToken,
   reportFailure,
@@ -525,15 +525,21 @@ test('run passes job_name through to bootstrap environment', () => {
   });
 
   assert.equal(execCall[2].env.JOB_NAME, 'build ubuntu-2204');
+  assert.match(execCall[2].env.JOB_EXTERNAL_ID, /^build matrix-[0-9a-f]{8}$/);
 });
 
-test('matrixIdentifier prefers label, then name, with a stable hash fallback', () => {
-  assert.equal(matrixIdentifier(JSON.stringify({ label: 'Linux AMD64', name: 'ubuntu-2204' })), 'Linux AMD64');
-  assert.equal(matrixIdentifier(JSON.stringify({ name: 'rockylinux-8' }, null, 2)), 'rockylinux-8');
+test('matrixIdentity separates the stable scan key from the readable scan label', () => {
+  const labeled = matrixIdentity(JSON.stringify({ label: 'Linux AMD64', name: 'ubuntu-2204' }));
+  assert.equal(labeled.scanLabel, 'Linux AMD64');
+  assert.match(labeled.scanKey, /^matrix-[0-9a-f]{8}$/);
 
-  const fallback = matrixIdentifier(JSON.stringify({ os: 'ubuntu-latest', node: 20 }));
-  assert.match(fallback, /^matrix-[0-9a-f]{8}$/);
-  assert.equal(fallback, matrixIdentifier(JSON.stringify({ os: 'ubuntu-latest', node: 20 })));
+  const named = matrixIdentity(JSON.stringify({ name: 'rockylinux-8' }, null, 2));
+  assert.equal(named.scanLabel, 'rockylinux-8');
+  assert.match(named.scanKey, /^matrix-[0-9a-f]{8}$/);
+
+  const fallback = matrixIdentity(JSON.stringify({ os: 'ubuntu-latest', node: 20 }));
+  assert.equal(fallback.scanLabel, fallback.scanKey);
+  assert.equal(fallback.scanKey, matrixIdentity(JSON.stringify({ os: 'ubuntu-latest', node: 20 })).scanKey);
 });
 
 test('run falls back to GITHUB_JOB when job_name expression is not evaluated', () => {
@@ -554,4 +560,5 @@ test('run falls back to GITHUB_JOB when job_name expression is not evaluated', (
   });
 
   assert.equal(execCall[2].env.JOB_NAME, 'build');
+  assert.equal(execCall[2].env.JOB_EXTERNAL_ID, 'build');
 });


### PR DESCRIPTION
## Summary

  Adds stable job identification and readable labels so scans can be consistently grouped and distinguished across workflow runs, including matrix jobs.

  ## Changes

  - Add optional job_identifier, job_label, and matrix_obj action inputs.
  - Derive both job values from GITHUB_JOB when not explicitly provided.
  - Generate a stable hashed identifier for matrix jobs.
  - Use the matrix label or name as the readable label when available.
  - Pass job_identifier and job_label to the bootstrap endpoint.
  - Preserve explicit job values without applying matrix decoration.
  - Add tests covering matrix, explicit, and default job identity behavior.

  Existing workflows require no changes unless they need custom identifiers or labels.